### PR TITLE
fix: check framework version before install

### DIFF
--- a/print_designer/hooks.py
+++ b/print_designer/hooks.py
@@ -66,7 +66,7 @@ jinja = {
 # Installation
 # ------------
 
-# before_install = "print_designer.install.before_install"
+before_install = "print_designer.install.before_install"
 after_install = "print_designer.install.after_install"
 
 # Uninstallation

--- a/print_designer/install.py
+++ b/print_designer/install.py
@@ -1,8 +1,27 @@
+import click
+import frappe
 from frappe.custom.doctype.custom_field.custom_field import \
     create_custom_fields
 
 from print_designer.custom_fields import CUSTOM_FIELDS
 
+def check_frappe_version():
+	def major_version(v: str) -> str:
+		return v.split(".")[0]
+
+	frappe_version = major_version(frappe.__version__)
+	if int(frappe_version) >= 15:
+	    return
+
+	click.secho(
+		f"You're attempting to install Print Designer with Frappe version {frappe_version}. "
+		"This is not supported and will result in broken install. Please install it using Version 15 or Develop branch.",
+		fg="red",
+	)
+	raise SystemExit(1)
+
+def before_install():
+	check_frappe_version()
 
 def after_install():
 	create_custom_fields(CUSTOM_FIELDS, ignore_validate=True)


### PR DESCRIPTION
Print Designer is not supported in version-14 so only allow installing if framework version is develop or more then v14.