### PR TITLE
Enable Network Printing

### DIFF
--- a/print_designer/print_designer/client_scripts/print.js
+++ b/print_designer/print_designer/client_scripts/print.js
@@ -213,6 +213,11 @@ frappe.ui.form.PrintView = class PrintView extends frappe.ui.form.PrintView {
 	}
 	printit() {
 		let me = this;
+		// Enable Network Printing
+		if(this.print_settings.enable_print_server) {
+			super.printit();
+			return;
+		}
 		if (this.get_print_format().print_designer) {
 			if (!this.pdfDoc) return;
 			this.pdfDoc.getData().then((arrBuff) => {


### PR DESCRIPTION
If Network Printing is enabled on the Frappe Site, we should utilize the `printit` function from `frappe.ui.form.PrintView`.