### PR TITLE
feat: allow hidden fields

### DIFF
--- a/print_designer/public/js/print_designer/components/layout/AppDynamicTextModal.vue
+++ b/print_designer/public/js/print_designer/components/layout/AppDynamicTextModal.vue
@@ -56,6 +56,21 @@
 								}, 300)
 							"
 						/>
+						<div class="hidden-toggle">
+							<label class="switch">
+								<input type="checkbox" :class="{ checked: hiddenFields }" :checked="hiddenFields"
+									@change="() => {
+										hiddenFields = !hiddenFields;
+									}"
+									@click="MainStore.isHiddenFieldsVisible = !MainStore.isHiddenFieldsVisible;"
+									>
+								<span class="slider round"></span>
+							</label>
+							<span>Hidden Fields</span>
+						</div>
+					</div>
+					<div class="form-message yellow" v-if="hiddenFields">
+						<div>Fields with <b>Print Hide</b> are now also visible and can be printed. please be careful while selecting fields </div>
 					</div>
 					<div class="container-main">
 						<div
@@ -63,6 +78,7 @@
 								selectedParentField: previewRef?.parentField,
 								selectedTable: table,
 								search_string: search_text,
+								show_hidden_fields: hiddenFields,
 							})"
 							:key="fieldtype"
 						>
@@ -137,7 +153,27 @@ const search_text = ref("");
 const doctype = ref("");
 const selectedDoctypeLabel = ref("");
 const fieldnames = ref([]);
+const hiddenFields = ref(false);
 const previewRef = ref(null);
+
+const allowHiddenFieldDisable = watch(
+	() => hiddenFields.value,
+	(newValue, oldValue) => {
+		if (newValue == false && oldValue == true) {
+			let hidden_fields = fieldnames.value.filter((el) => el.print_hide).map((el) => el.label || el.fieldname);
+			if (!hidden_fields.length) return;
+			hiddenFields.value = true;
+			message = __("Please First remove hidden fields [ " + [...hidden_fields].join(", ") + " ]");
+			frappe.show_alert(
+				{
+					message: message,
+					indicator: "red",
+				},
+				5
+			);
+		}
+	}
+);
 
 const parentFieldWatcher = watch(
 	() => previewRef.value?.parentField,
@@ -168,6 +204,10 @@ onMounted(() => {
 		selectedDoctypeLabel.value = MainStore.doctype;
 		if (props.table) {
 			fieldnames.value = props.openDynamicModal.dynamicContent || [];
+		}
+		fieldnames.value.findIndex((fd) => fd.print_hide) != -1 && (hiddenFields.value = true);
+		if (!hiddenFields.value) {
+			hiddenFields.value = MainStore.isHiddenFieldsVisible
 		}
 	}
 });
@@ -264,6 +304,7 @@ const selectField = async (field, fieldtype) => {
 		label: props.table ? field.label : `${field.label} :`,
 		is_labelled: false,
 		is_static: false,
+		print_hide: field.print_hide,
 		style: {},
 		tableName: props.table?.fieldname,
 		labelStyle: {},
@@ -444,11 +485,34 @@ small {
 			border-radius: 6px;
 		}
 		.searchbar-sticky {
+			display: flex;
 			margin-bottom: 0;
 			position: sticky;
 			top: 0;
 			z-index: 1;
 			background-color: var(--fg-color);
+
+			.searchbar {
+				flex: 5;
+			}
+
+			.hidden-toggle {
+				display: flex;
+				gap: 5px;
+				padding: var(--padding-sm);
+
+				.switch > .checked {
+					& + .slider {
+						background-color: var(--invert-neutral);
+					}
+
+					& + .slider:before {
+						-webkit-transform: translateX(10px);
+						-ms-transform: translateX(10px);
+						transform: translateX(10px);
+					}
+				}
+			}
 		}
 		.container-main {
 			padding: var(--padding-sm) 15px 0px var(--padding-sm);

--- a/print_designer/public/js/print_designer/store/MainStore.js
+++ b/print_designer/public/js/print_designer/store/MainStore.js
@@ -58,6 +58,7 @@ export const useMainStore = defineStore("MainStore", {
 		lastCloned: null,
 		currentDrawListener: null,
 		isMoved: false,
+		isHiddenFieldsVisible: false,
 		currentPageSize: "A4",
 		pageSizes,
 		lastCreatedElement: null,
@@ -231,6 +232,7 @@ export const useMainStore = defineStore("MainStore", {
 				selectedParentField = null,
 				selectedTable = null,
 				search_string = null,
+				show_hidden_fields = false,
 			}) => {
 				let fields = {};
 				let metaFields = state.metaFields;
@@ -240,6 +242,9 @@ export const useMainStore = defineStore("MainStore", {
 					).childfields;
 				} else if (selectedTable) {
 					metaFields = selectedTable.childfields;
+				}
+				if (!show_hidden_fields){
+					metaFields = metaFields.filter((field) => !field["print_hide"]);
 				}
 				if (typeof search_string == "string" && search_string.length) {
 					metaFields = metaFields.filter(

--- a/print_designer/public/js/print_designer/store/fetchMetaAndData.js
+++ b/print_designer/public/js/print_designer/store/fetchMetaAndData.js
@@ -11,8 +11,7 @@ export const fetchMeta = () => {
 			MainStore.rawMeta = markRaw(frappe.get_meta(print_format.doc_type));
 			let metaFields = frappe.get_meta(print_format.doc_type).fields.filter((df) => {
 				if (
-					["Section Break", "Column Break", "Tab Break", "Image"].includes(df.fieldtype) ||
-					(df.print_hide == 1 && df.fieldtype != "Link")
+					["Section Break", "Column Break", "Tab Break", "Image"].includes(df.fieldtype)
 				) {
 					return false;
 				} else {
@@ -20,16 +19,17 @@ export const fetchMeta = () => {
 				}
 			});
 			metaFields.map((field) => {
-				if (field["print_hide"] && field["fieldtype"] != "Link") return;
+				
 				let obj = {};
-				["fieldname", "fieldtype", "label", "options"].forEach((attr) => {
+				["fieldname", "fieldtype", "label", "options", "print_hide"].forEach((attr) => {
 					obj[attr] = field[attr];
 				});
 				MainStore.metaFields.push({ ...obj });
 			});
 			metaFields.map((field) => {
-				if (field["fieldtype"] != "Table" || field["print_hide"]) return;
-				getMeta(field.options, field.fieldname);
+				if (field["fieldtype"] == "Table") {
+					getMeta(field.options, field.fieldname);
+				}
 			});
 			fetchDoc();
 			!MainStore.getTableMetaFields.length && (MainStore.controls.Table.isDisabled = true);


### PR DESCRIPTION
currently, print designer honours the `print_hide` property of fields, community feedback suggests that this should be configurable so added a toggle that will make even hidden fields visible.


https://github.com/frappe/print_designer/assets/39730881/50017253-f24a-403b-b57f-810d0585e5bb

Closes #65 