### PR TITLE
chore: python-barcode version upgrade to 0.15.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = ["version"]
 dependencies = [
     "PyQRCode~=1.2.1",
     "pypng~=0.20220715.0",
-    "python-barcode~=0.13.1",
+    "python-barcode~=0.15.1",
 ]
 
 [build-system]


### PR DESCRIPTION
python-barcode version upgraded.

#89 