### PR TITLE
fix(minor): remove dpi arg from PDSVGWriter

### DIFF
--- a/print_designer/print_designer/page/print_designer/print_designer.py
+++ b/print_designer/print_designer/page/print_designer/print_designer.py
@@ -102,7 +102,7 @@ def get_barcode(barcode_format, barcode_value, options={}, width=None, height=No
 			SVGWriter.__init__(self)
 
 		def calculate_viewbox(self, code):
-			vw, vh = self.calculate_size(len(code[0]), len(code), self.dpi)
+			vw, vh = self.calculate_size(len(code[0]), len(code))
 			return vw, vh
 
 		def _init(self, code):


### PR DESCRIPTION
python-barcode library removed the dpi argument from calculate_size function, so we need to remove it from our code as well. https://github.com/WhyNotHugo/python-barcode/commit/f103c836b6bb12f16b39daca90b4f985b7d89bff