### PR TITLE
fix: text outside page when preformatted

### DIFF
--- a/print_designer/print_designer/page/print_designer/jinja/main.html
+++ b/print_designer/print_designer/page/print_designer/jinja/main.html
@@ -1,7 +1,7 @@
 {% macro render_statictext(element) -%}
-<div style="position: absolute; top:{% if 'printY' in element %}{{ element.printY }}{% else %}{{ element.startY }}{% endif %}px; left:{% if 'printX' in element %}{{ element.printX }}{% else %}{{ element.startX }}{% endif %}px;{% if element.isFixedSize %}width:{{ element.width }}px;height:{{ element.height }}px;{% else %}width:fit-content; height:fit-content; white-space:nowrap;{%endif%}" class="
+<div style="position: absolute; top:{% if 'printY' in element %}{{ element.printY }}{% else %}{{ element.startY }}{% endif %}px; left:{% if 'printX' in element %}{{ element.printX }}{% else %}{{ element.startX }}{% endif %}px;{% if element.isFixedSize %}width:{{ element.width }}px;height:{{ element.height }}px;{% else %}width:fit-content; height:fit-content; max-width: {{ settings.page.width - settings.page.marginLeft - settings.page.marginRight - element.startX }}px; {%endif%}" class="
     {{ element.classes | join(' ') }}">
-    <p style="{% if element.isFixedSize %}width:{{ element.width }}px;height:{{ element.height }}px;{% else %}width:fit-content; height:fit-content; white-space:nowrap;{%endif%} {{convert_css(element.style)}}"
+    <p style="{% if element.isFixedSize %}width:{{ element.width }}px;height:{{ element.height }}px;{% else %}width:fit-content; height:fit-content; max-width: {{ settings.page.width - settings.page.marginLeft - settings.page.marginRight - element.startX }}px; {%endif%} {{convert_css(element.style)}}"
         class="staticText {{ element.classes | join(' ') }}">
         {{_(element.content)}}
     </p>
@@ -13,9 +13,9 @@
     {% endif %}
 {% endmacro %}
 {% macro render_dynamictext(element) -%}
-<div style="position: absolute; top:{% if 'printY' in element %}{{ element.printY }}{% else %}{{ element.startY }}{% endif %}px; left:{% if 'printX' in element %}{{ element.printX }}{% else %}{{ element.startX }}{% endif %}px;{% if element.isFixedSize %}width:{{ element.width }}px;height:{{ element.height }}px;{% else %}width:fit-content; height:fit-content; white-space:nowrap;{%endif%}" class="
+<div style="position: absolute; top:{% if 'printY' in element %}{{ element.printY }}{% else %}{{ element.startY }}{% endif %}px; left:{% if 'printX' in element %}{{ element.printX }}{% else %}{{ element.startX }}{% endif %}px;{% if element.isFixedSize %}width:{{ element.width }}px;height:{{ element.height }}px;{% else %}width:fit-content; height:fit-content; max-width: {{ settings.page.width - settings.page.marginLeft - settings.page.marginRight - element.startX }}px;{%endif%}" class="
     {{ element.classes | join(' ') }}">
-        <div style="{% if element.isFixedSize %}width:{{ element.width }}px;height:{{ element.height }}px;{% else %}width:fit-content; height:fit-content; white-space:nowrap;{%endif%} {{convert_css(element.style)}}"
+        <div style="{% if element.isFixedSize %}width:{{ element.width }}px;height:{{ element.height }}px;{% else %}width:fit-content; height:fit-content; max-width: {{ settings.page.width - settings.page.marginLeft - settings.page.marginRight - element.startX }}px;{%endif%} {{convert_css(element.style)}}"
             class="dynamicText {{ element.classes | join(' ') }}">
             {% for field in element.dynamicContent %}
             {{ render_spantag(field, element)}}

--- a/print_designer/public/js/print_designer/components/base/BaseDynamicText.vue
+++ b/print_designer/public/js/print_designer/components/base/BaseDynamicText.vue
@@ -5,7 +5,11 @@
 		@mouseup="handleMouseUp"
 		:style="[
 			postionalStyles(startX, startY, width, height),
-			!isFixedSize && 'width:fit-content; height:fit-content; white-space:nowrap;',
+			!isFixedSize && {
+				width:'fit-content', 
+				height:'fit-content', 
+				maxWidth: MainStore.page.width - MainStore.page.marginLeft - MainStore.page.marginRight - startX + 'px',
+			},
 		]"
 		:class="MainStore.getCurrentElementsId.includes(id) ? 'active-elements' : 'text-hover'"
 		:ref="setElements(object, index)"
@@ -15,7 +19,11 @@
 			:style="[
 				style,
 				widthHeightStyle(width, height),
-				!isFixedSize && 'width:fit-content; height:fit-content; white-space:nowrap;',
+				!isFixedSize && {
+					width:'fit-content', 
+					height:'fit-content', 
+					maxWidth: MainStore.page.width - MainStore.page.marginLeft - MainStore.page.marginRight - startX + 'px',
+				},
 			]"
 			:class="['dynamicText', classes]"
 			v-if="type == 'text'"

--- a/print_designer/public/js/print_designer/components/base/BaseStaticText.vue
+++ b/print_designer/public/js/print_designer/components/base/BaseStaticText.vue
@@ -5,7 +5,11 @@
 		@mouseup="handleMouseUp"
 		:style="[
 			postionalStyles(startX, startY, width, height),
-			!isFixedSize && 'width:fit-content; height:fit-content; white-space:nowrap;',
+			!isFixedSize && {
+				width:'fit-content', 
+				height:'fit-content', 
+				maxWidth: MainStore.page.width - MainStore.page.marginLeft - MainStore.page.marginRight - startX + 'px',
+			},
 		]"
 		:class="MainStore.getCurrentElementsId.includes(id) ? 'active-elements' : 'text-hover'"
 		:ref="setElements(object, index)"
@@ -20,7 +24,12 @@
 			:style="[
 				style,
 				widthHeightStyle(width, height),
-				!isFixedSize && 'width:fit-content; height:fit-content; white-space:nowrap;',
+				!isFixedSize && {
+					width:'fit-content', 
+					height:'fit-content', 
+					maxWidth: MainStore.page.width - MainStore.page.marginLeft - MainStore.page.marginRight - startX + 'px',
+				},
+
 			]"
 			:class="['staticText', classes]"
 			v-if="type == 'text'"


### PR DESCRIPTION
When Text is preformatted, it is not wrapped and can go outside the page. added max-width to preformatted text to prevent this.

Also, removed white-space: nowrap; it was added because there was some issue with wkhtmltopdf which breaks text.
don't remember when this happens so will revert this if it breaks again.

## Before
<img width="1428" alt="Screenshot 2023-12-04 at 12 11 32 AM" src="https://github.com/frappe/print_designer/assets/39730881/684592b9-a433-4327-9e42-284a70725372">

## After
<img width="1433" alt="Screenshot 2023-12-04 at 12 12 05 AM" src="https://github.com/frappe/print_designer/assets/39730881/524f42cc-2bf8-4837-a110-551a420f7bbc">


Closes #22 
