### PR TITLE
feat: jinja rendering for print designer

### DIFF
--- a/print_designer/patches.txt
+++ b/print_designer/patches.txt
@@ -1,2 +1,3 @@
 print_designer.patches.update_white_space_property
 print_designer.patches.introduce_barcode
+print_designer.patches.introduce_jinja

--- a/print_designer/patches/introduce_jinja.py
+++ b/print_designer/patches/introduce_jinja.py
@@ -1,0 +1,14 @@
+import frappe
+from print_designer.patches.patch_utils import patch_formats
+def execute():
+	""" Add parseJinja property in DynamicFields (Static) and staticText """
+	def element_callback(el):
+		if el.get("type") == "text" and not el.get("isDynamic"):
+			el["parseJinja"] = False
+	def dynamic_content_callback(el):
+		if el.get("is_static", False):
+			el["parseJinja"] = False
+	patch_formats({
+		"element": element_callback,
+		"dynamic_content": dynamic_content_callback
+	}, types=["text", "table", "barcode"])

--- a/print_designer/print_designer/page/print_designer/jinja/main.html
+++ b/print_designer/print_designer/page/print_designer/jinja/main.html
@@ -3,7 +3,11 @@
     {{ element.classes | join(' ') }}">
     <p style="{% if element.isFixedSize %}width:{{ element.width }}px;height:{{ element.height }}px;{% else %}width:fit-content; height:fit-content; max-width: {{ settings.page.width - settings.page.marginLeft - settings.page.marginRight - element.startX }}px; {%endif%} {{convert_css(element.style)}}"
         class="staticText {{ element.classes | join(' ') }}">
-        {{_(element.content)}}
+        {% if element.parseJinja %}
+            {{frappe.render_template(element.content, {'doc': doc})}}
+        {% else %}
+            {{_(element.content)}}
+        {% endif %}
     </p>
 </div>
 {%- endmacro %}
@@ -50,7 +54,11 @@ background-image: url('{{frappe.get_url()}}{%if element.isDynamic %}{{element.im
 {% macro render_barcode(element) -%}
 {%- set field = element.dynamicContent[0] -%}
 {%- if field.is_static -%}
-{%- set value = field.value -%}
+    {% if field.parseJinja %}
+        {%- set value = frappe.render_template(field.value, {'doc': doc}) -%}
+    {% else %}
+        {%- set value =  _(field.value) -%}
+{% endif %}
 {%- elif field.doctype -%}
 {%- set value = frappe.db.get_value(field.doctype, doc[field.parentField], field.fieldname) -%}
 {%- else -%}
@@ -112,7 +120,11 @@ background-image: url('{{frappe.get_url()}}{%if element.isDynamic %}{{element.im
 {%- endmacro %}
 {%- macro render_spanvalue(field, element, row) -%}
 {%- if field.is_static -%}
-{{ _(field.value) }}
+    {% if field.parseJinja %}
+        {{frappe.render_template(field.value, {'doc': doc, 'row': row})}}
+    {% else %}
+        {{ _(field.value) }}
+    {% endif %}
 {%- elif field.doctype -%}
 {%- set value = _(frappe.db.get_value(field.doctype, doc[field.parentField], field.fieldname)) -%}
 {{ frappe.format(value, {'fieldtype': field.fieldtype, 'options': field.options}) }}

--- a/print_designer/print_designer/page/print_designer/print_designer.py
+++ b/print_designer/print_designer/page/print_designer/print_designer.py
@@ -91,6 +91,16 @@ def get_barcode(barcode_format, barcode_value, options={}, width=None, height=No
 		import re
 		barcode_value = re.search(r'data-barcode-value="(.*?)">', barcode_value).group(1)
 	
+	if barcode_value == '':
+		fallback_html_string = '''
+			<div class="fallback-barcode">
+				<div class="content">
+					<span>No Value was Provided to Barcode</span>
+				</div>
+			</div>
+		'''
+		return { "type": "svg", "value": fallback_html_string }
+	
 	if barcode_format == "qrcode": return get_qrcode(barcode_value, options, png_base64)
 	
 	import barcode

--- a/print_designer/public/js/print_designer/PropertiesPanelState.js
+++ b/print_designer/public/js/print_designer/PropertiesPanelState.js
@@ -520,6 +520,52 @@ export const createPropertiesPanel = () => {
 		],
 	});
 	MainStore.propertiesPanel.push({
+		title: "Enable Jinja Parsing",
+		sectionCondtional: () =>
+			MainStore.getCurrentElementsId.length === 1 &&
+			(MainStore.getCurrentElementsValues[0].type === "text" &&
+				!MainStore.getCurrentElementsValues[0].isDynamic),
+		fields: [
+			[
+				{
+					label: "Render Jinja",
+					name: "parseJinja",
+					labelDirection: "column",
+					condtional: () =>
+					MainStore.getCurrentElementsId.length === 1 &&
+					(MainStore.getCurrentElementsValues[0].type === "text" &&
+						!MainStore.getCurrentElementsValues[0].isDynamic),
+					frappeControl: (ref, name) => {
+						const MainStore = useMainStore();
+						makeFeild({
+							name: name,
+							ref: ref,
+							fieldtype: "Select",
+							requiredData: [MainStore.getCurrentElementsValues[0]],
+							options: () => [
+								{ label: "Yes", value: "Yes" },
+								{ label: "No", value: "No" },
+							],
+							formatValue: (object, property, isStyle) => {
+								if (!object) return;
+								return object[property] ? "Yes" : "No";
+							},
+							onChangeCallback: (value = null) => {
+								if (value && MainStore.getCurrentElementsValues[0]) {
+									MainStore.getCurrentElementsValues[0]["parseJinja"] =
+										value === "Yes";
+									MainStore.frappeControls[name].$input.blur();
+								}
+							},
+							reactiveObject: () => MainStore.getCurrentElementsValues[0],
+							propertyName: "parseJinja",
+						});
+					},
+				},
+			],
+		],
+	});
+	MainStore.propertiesPanel.push({
 		title: "Text Tool",
 		sectionCondtional: () => MainStore.activeControl === "text",
 		fields: [

--- a/print_designer/public/js/print_designer/components/layout/AppDynamicPreviewModal.vue
+++ b/print_designer/public/js/print_designer/components/layout/AppDynamicPreviewModal.vue
@@ -98,6 +98,13 @@
 				></span>
 				<span :style="['font-size: 12px; padding: 0px 5px', selectedEl.field.nextLine && 'color:var(--primary)']">{{selectedEl.field.nextLine ? "Remove Line" : "New Line"}}</span>
 			</div>
+			<div v-if="selectedEl && selectedEl.field.is_static" @click="selectedEl.field.parseJinja = !selectedEl.field.parseJinja">
+				<span
+					class="jinja-toggle fa fa-code"
+					:style="[selectedEl.field.parseJinja && 'color:var(--primary)']"
+				></span>
+				<span :style="['font-size: 12px; padding: 0px 5px', selectedEl.field.parseJinja && 'color:var(--primary)']">{{selectedEl.field.parseJinja ? "Disable Jinja" : "Render Jinja"}}</span>
+			</div>
 		</div>
 		<div
 			class="deleteIcon"
@@ -218,6 +225,7 @@ const addStaticText = (event) => {
 		is_static: true,
 		is_labelled: false,
 		nextLine: false,
+		parseJinja: false,
 		style: {},
 	};
 	if (selectedEl.value) {
@@ -350,7 +358,7 @@ const deleteField = (ev) => {
 			}
 		}
 
-		.next-line {
+		.next-line, .jinja-toggle {
 			margin: 0px 7px;
 			color: var(--text-muted);
 		}

--- a/print_designer/public/js/print_designer/defaultObjects.js
+++ b/print_designer/public/js/print_designer/defaultObjects.js
@@ -200,6 +200,7 @@ export const createText = (cordinates, parent = null) => {
 		isDraggable: false,
 		isResizable: false,
 		isDropZone: false,
+		parseJinja: false,
 		startX: cordinates.startX - 5,
 		startY: cordinates.startY - 16,
 		pageX: cordinates.pageX,


### PR DESCRIPTION
- Added Support for templates rendering when you need something custom.
- On Print Designer client side we use Simple JavaScript Templating ( microtemplate.js in framework ) to render the preview.
-  Modified main.html which is used to generate pdf to parse jinja where required.
- Added fallback value to barcode so it will return blank html if empty value is set.


https://github.com/frappe/print_designer/assets/39730881/c306590b-fab9-4761-828b-bd21e4f07c8d

Closes #74