### PR TITLE
feat(minor): add schema versioning

### DIFF
--- a/print_designer/patches.txt
+++ b/print_designer/patches.txt
@@ -1,3 +1,4 @@
 print_designer.patches.update_white_space_property
 print_designer.patches.introduce_barcode
 print_designer.patches.introduce_jinja
+print_designer.patches.introduce_schema_versioning

--- a/print_designer/patches/introduce_schema_versioning.py
+++ b/print_designer/patches/introduce_schema_versioning.py
@@ -1,0 +1,10 @@
+import frappe
+
+def execute():
+	"""Adds Schema Versioning for Print Designer inside Print Format Settings to handle changes that are not patchable and needs to be handled in the code"""
+	print_formats = frappe.get_all("Print Format", filters={"print_designer": 1}, fields=["name", "print_designer_settings"], as_list=1)
+	for pf in print_formats:
+		settings = frappe.parse_json(pf[1])
+		if settings:
+			settings["schema_version"] = "1.0.0"
+			frappe.db.set_value("Print Format", pf[0], "print_designer_settings", frappe.as_json(settings))

--- a/print_designer/public/js/print_designer/store/ElementStore.js
+++ b/print_designer/public/js/print_designer/store/ElementStore.js
@@ -266,6 +266,7 @@ export const useElementStore = defineStore("ElementStore", {
 				printHeaderFonts: MainStore.printHeaderFonts,
 				printFooterFonts: MainStore.printFooterFonts,
 				printBodyFonts: MainStore.printBodyFonts,
+				schema_version: MainStore.schema_version,
 			};
 			await frappe.dom.freeze();
 			const convertCsstoString = (stylesheet) => {

--- a/print_designer/public/js/print_designer/store/MainStore.js
+++ b/print_designer/public/js/print_designer/store/MainStore.js
@@ -17,6 +17,7 @@ export const useMainStore = defineStore("MainStore", {
 		/**
 		 * @type {'editing'|'pdfSetup'|'preview'} mode
 		 */
+		schema_version: "1.0.0",
 		mode: "editing",
 		cursor: "cursor: url('/assets/print_designer/images/mouse-pointer.svg'), default !important",
 		isMarqueeActive: false,


### PR DESCRIPTION
In some cases patching old data is not possible without user intervention. 
When This the case, we can change the schema version and handle in code until user opens print designer and it is handled on save.