### PR TITLE
fix: allow setting primary table

### DIFF
--- a/print_designer/print_designer/page/print_designer/jinja/main.html
+++ b/print_designer/print_designer/page/print_designer/jinja/main.html
@@ -114,8 +114,10 @@ background-image: url('{{frappe.get_url()}}{%if element.isDynamic %}{{element.im
         {% endif %}
         </tbody>
     </table>
-    {% set renderAfterTableElement =  render_element(afterTableElement) %}
-    {% if renderAfterTableElement %}<div style="position: relative; top:0px; left: 0px;">{{ renderAfterTableElement }}</div>{% endif %}
+    {% if element.get("isPrimaryTable", false) or settings.get("schema_version") == "1.0.0" %}
+        {% set renderAfterTableElement =  render_element(afterTableElement) %}
+        {% if renderAfterTableElement %}<div style="position: relative; top:0px; left: 0px;">{{ renderAfterTableElement }}</div>{% endif %}
+    {% endif %}
 </div>
 {%- endmacro %}
 {%- macro render_spanvalue(field, element, row) -%}

--- a/print_designer/public/js/print_designer/PropertiesPanelState.js
+++ b/print_designer/public/js/print_designer/PropertiesPanelState.js
@@ -1,4 +1,5 @@
 import { useMainStore } from "./store/MainStore";
+import { useElementStore } from "./store/ElementStore";
 import { makeFeild } from "./frappeControl";
 import { storeToRefs } from "pinia";
 import {
@@ -501,6 +502,43 @@ export const createPropertiesPanel = () => {
 									MainStore.frappeControls["no_of_rows"].set_value(
 										MainStore.frappeControls["no_of_rows"].last_value
 									);
+								}
+							},
+						});
+					},
+					flex: 1,
+				},
+			],
+			[
+				{
+					label: "Set as Primary Table",
+					name: "isPrimaryTable",
+					isLabelled: true,
+					labelDirection: "column",
+					condtional: () => MainStore.getCurrentElementsValues[0]?.table,
+					frappeControl: (ref, name) => {
+						const MainStore = useMainStore();
+						const ElementStore = useElementStore();
+						makeFeild({
+							name,
+							ref,
+							fieldtype: "Select",
+							requiredData: [MainStore.getCurrentElementsValues[0]],
+							reactiveObject: () => MainStore.getCurrentElementsValues[0],
+							propertyName: "isPrimaryTable",
+							isStyle: false,
+							options: () => [
+								{ label: "Yes", value: "Yes" },
+								{ label: "No", value: "No" },
+							],
+							formatValue: (object, property, isStyle) => {
+								if (!object) return;
+								return object[property] ? "Yes" : "No";
+							},
+							onChangeCallback: (value = null) => {
+								if (value && MainStore.getCurrentElementsValues[0]) {
+									ElementStore.setPrimaryTable(MainStore.getCurrentElementsValues[0], value === "Yes")
+									MainStore.frappeControls[name].$input.blur();
 								}
 							},
 						});

--- a/print_designer/public/js/print_designer/store/ElementStore.js
+++ b/print_designer/public/js/print_designer/store/ElementStore.js
@@ -142,6 +142,27 @@ export const useElementStore = defineStore("ElementStore", {
 			let isBodyEmpty = true;
 			let isFooterEmpty = true;
 			let pageInfoInBody = [];
+			if (tableElement.length == 1) {
+				tableElement[0].isPrimaryTable = true;
+			}
+			else if (tableElement.length > 1) {
+				let primaryTableEl = tableElement.filter((el) => el.isPrimaryTable)
+				if (primaryTableEl.length == 1) {
+					tableElement = primaryTableEl
+				} else {
+					const message = __(
+						"As You have multiple tables, you have to select Primary Table. <br></br> 1. Go to Table Element that you wish to set as Primary. <br></br> 2. Select it and from properties panel select <b>Set as Primary Table</b> as <b>Yes</b> ")
+					frappe.msgprint(
+						{
+							title: __("Multiple Tables."),
+							message: message,
+							indicator: "red",
+						},
+						5
+					);
+					return;
+				}
+			}
 			this.Elements.forEach((element) => {
 				let is_header = false;
 				let is_footer = false;
@@ -458,5 +479,15 @@ export const useElementStore = defineStore("ElementStore", {
 			});
 			frappe.dom.unfreeze();
 		},
+		setPrimaryTable(tableEl, value) {
+			if (!value){
+				tableEl.isPrimaryTable = value;
+				return
+			}
+			tables = this.Elements.filter((el) => el.type == "table");
+			tables.forEach((t) => {
+				t.isPrimaryTable = t == tableEl
+			})
+		}
 	},
 });

--- a/print_designer/public/js/print_designer/store/MainStore.js
+++ b/print_designer/public/js/print_designer/store/MainStore.js
@@ -17,7 +17,7 @@ export const useMainStore = defineStore("MainStore", {
 		/**
 		 * @type {'editing'|'pdfSetup'|'preview'} mode
 		 */
-		schema_version: "1.0.0",
+		schema_version: "1.0.1",
 		mode: "editing",
 		cursor: "cursor: url('/assets/print_designer/images/mouse-pointer.svg'), default !important",
 		isMarqueeActive: false,


### PR DESCRIPTION
As users can have multiple Tables. I have added a workaround to set any table as Primary and that table will span across multiple pages and everything after table will be printed after table.

Workaround Fixes : #103 

https://github.com/frappe/print_designer/assets/39730881/a57832d8-92b2-44c4-9878-09d7df3b994f


