### PR TITLE
fix: don't update schema_version on load

### DIFF
--- a/print_designer/public/js/print_designer/store/ElementStore.js
+++ b/print_designer/public/js/print_designer/store/ElementStore.js
@@ -312,8 +312,11 @@ export const useElementStore = defineStore("ElementStore", {
 			let settings = JSON.parse(printFormat.message.print_designer_settings);
 			settings &&
 				Object.keys(settings).forEach( async (key) => {
-					if (key != "currentDoc" || await frappe.db.exists(MainStore.doctype, settings[key])) {
+					if (["currentDoc", "schema_version"].indexOf(key) == -1 || await frappe.db.exists(MainStore.doctype, settings[key])) {
 						MainStore[key] = settings[key];
+					}
+					if (key == "schema_version" && settings[key] != MainStore.schema_version) {
+						MainStore.old_schema_version = settings[key];
 					}
 				});
 			const handleDynamicContent = (element) => {


### PR DESCRIPTION
schema_version is suppose to indicate new data version. 

instead of updating it from db on load we will save it as old_schema_version 

As when we save, we are suppose to fix the state that we couldn't do using patches.

we want to fix the schema and update the schema version on save.