### PR TITLE
feat: custom jinja data template

### DIFF
--- a/print_designer/hooks.py
+++ b/print_designer/hooks.py
@@ -57,6 +57,7 @@ doctype_js = {"Print Format": "print_designer/client_scripts/print_format.js"}
 # add methods and filters to jinja environment
 jinja = {
 	"methods": [
+		"print_designer.print_designer.page.print_designer.print_designer.render_user_text",
 		"print_designer.print_designer.page.print_designer.print_designer.convert_css",
 		"print_designer.print_designer.page.print_designer.print_designer.convert_uom",
 		"print_designer.print_designer.page.print_designer.print_designer.get_barcode",

--- a/print_designer/pdf.py
+++ b/print_designer/pdf.py
@@ -35,7 +35,7 @@ def pdf_header_footer_html(soup, head, content, styles, html_id, css):
 
 def pdf_body_html(print_format, jenv, args, template):
 	if print_format and print_format.print_designer and print_format.print_designer_body:
-		template = jenv.get_template("print_designer/page/print_designer/jinja/main.html")
+		template = jenv.loader.get_source(jenv, "print_designer/page/print_designer/jinja/main.html")[0]
 		args.update(
 			{
 				"headerElement": json.loads(print_format.print_designer_header),
@@ -45,4 +45,7 @@ def pdf_body_html(print_format, jenv, args, template):
 				"settings": json.loads(print_format.print_designer_settings),
 			}
 		)
+		# replace placeholder comment with user provided jinja code
+		template_source = template.replace('<!-- user_generated_jinja_code -->', args["settings"].get("userProvidedJinja", ""))
+		template = jenv.from_string(template_source)
 	return template.render(args, filters={"len": len})

--- a/print_designer/print_designer/page/print_designer/jinja/main.html
+++ b/print_designer/print_designer/page/print_designer/jinja/main.html
@@ -1,10 +1,11 @@
-{% macro render_statictext(element) -%}
+{% macro render_statictext(element, send_to_jinja) -%}
 <div style="position: absolute; top:{% if 'printY' in element %}{{ element.printY }}{% else %}{{ element.startY }}{% endif %}px; left:{% if 'printX' in element %}{{ element.printX }}{% else %}{{ element.startX }}{% endif %}px;{% if element.isFixedSize %}width:{{ element.width }}px;height:{{ element.height }}px;{% else %}width:fit-content; height:fit-content; max-width: {{ settings.page.width - settings.page.marginLeft - settings.page.marginRight - element.startX }}px; {%endif%}" class="
     {{ element.classes | join(' ') }}">
     <p style="{% if element.isFixedSize %}width:{{ element.width }}px;height:{{ element.height }}px;{% else %}width:fit-content; height:fit-content; max-width: {{ settings.page.width - settings.page.marginLeft - settings.page.marginRight - element.startX }}px; {%endif%} {{convert_css(element.style)}}"
         class="staticText {{ element.classes | join(' ') }}">
         {% if element.parseJinja %}
-            {{frappe.render_template(element.content, {'doc': doc})}}
+        <!-- third Arg is row which is not sent outside table -->
+           {{ render_user_text(element.content, doc, {}, send_to_jinja) }}
         {% else %}
             {{_(element.content)}}
         {% endif %}
@@ -16,23 +17,24 @@
         page_info_{{ field.fieldname }}
     {% endif %}
 {% endmacro %}
-{% macro render_dynamictext(element) -%}
+{% macro render_dynamictext(element, send_to_jinja) -%}
 <div style="position: absolute; top:{% if 'printY' in element %}{{ element.printY }}{% else %}{{ element.startY }}{% endif %}px; left:{% if 'printX' in element %}{{ element.printX }}{% else %}{{ element.startX }}{% endif %}px;{% if element.isFixedSize %}width:{{ element.width }}px;height:{{ element.height }}px;{% else %}width:fit-content; height:fit-content; max-width: {{ settings.page.width - settings.page.marginLeft - settings.page.marginRight - element.startX }}px;{%endif%}" class="
     {{ element.classes | join(' ') }}">
         <div style="{% if element.isFixedSize %}width:{{ element.width }}px;height:{{ element.height }}px;{% else %}width:fit-content; height:fit-content; max-width: {{ settings.page.width - settings.page.marginLeft - settings.page.marginRight - element.startX }}px;{%endif%} {{convert_css(element.style)}}"
             class="dynamicText {{ element.classes | join(' ') }}">
             {% for field in element.dynamicContent %}
-            {{ render_spantag(field, element)}}
+            <!-- third Arg is row which is not sent outside table -->
+            {{ render_spantag(field, element, {}, send_to_jinja)}}
             {% endfor %}
         </div>
 </div>
 {%- endmacro %}
-{% macro render_rectangle(element) -%}
+{% macro render_rectangle(element, send_to_jinja) -%}
 <div id="{{ element.id }}" style="position: absolute; top:{% if 'printY' in element %}{{ element.printY }}{% else %}{{ element.startY }}{% endif %}px; left:{% if 'printX' in element %}{{ element.printX }}{% else %}{{ element.startX }}{% endif %}px; width:{{ element.width }}px;height:{{ element.height }}px; {{convert_css(element.style)}}"
     class="rectangle {{ element.classes | join(' ') }}">
     {% if element.childrens %}
     {% for object in element.childrens %}
-    {{ render_element(object)}}
+    {{ render_element(object, send_to_jinja)}}
     {% endfor %}
     {% endif %}
 </div>
@@ -51,11 +53,11 @@ background-image: url('{{frappe.get_url()}}{%if element.isDynamic %}{{element.im
 ></div>
 </div>
 {%- endmacro %}
-{% macro render_barcode(element) -%}
+{% macro render_barcode(element, send_to_jinja) -%}
 {%- set field = element.dynamicContent[0] -%}
 {%- if field.is_static -%}
     {% if field.parseJinja %}
-        {%- set value = frappe.render_template(field.value, {'doc': doc}) -%}
+        {%- set value = render_user_text(field.value, doc, {}, send_to_jinja) -%}
     {% else %}
         {%- set value =  _(field.value) -%}
 {% endif %}
@@ -80,8 +82,8 @@ background-image: url('{{frappe.get_url()}}{%if element.isDynamic %}{{element.im
     }).value}}{% endif %}</div>
 </div>
 {%- endmacro %}
-{% macro render_table(element) -%}
-<div style="position: absolute; top:{% if 'printY' in element %}{{ element.printY }}{% else %}{{ element.startY }}{% endif %}px; left:{%if element.startX >= 1%}{{ element.startX }}{%else%}{{element.startX}}{%endif%}px;width:{{ element.width }}px;height:{{ element.height }}px;" class="
+{% macro render_table(element, send_to_jinja) -%}
+<div style="position: absolute; top:{% if 'printY' in element %}{{ element.printY }}{% else %}{{ element.startY }}{% endif %}px; left:{% if 'printX' in element %}{{ element.printX }}{% else %}{{ element.startX }}{% endif %}px;width:{{ element.width }}px;height:{{ element.height }}px;" class="
     table-container {{ element.classes | join(' ') }}">
     <table class="printTable" style="position: relative; width:100%; max-width:{{ element.width }}px;">
         <thead>
@@ -104,7 +106,7 @@ background-image: url('{{frappe.get_url()}}{%if element.isDynamic %}{{element.im
                 <td style="{{convert_css(element.style)}}{%if isLastRow%}border-bottom-style: solid !important;{%endif%}{%if loop.first%}border-left-style: solid !important;{%elif loop.last%}border-right-style: solid !important;{%endif%}">
             {% if column is mapping %}
                 {% for field in column.dynamicContent%}
-                    {{ render_spantag(field, element, row) }}
+                    {{ render_spantag(field, element, row, send_to_jinja) }}
                 {% endfor %}
         {% endif %}
                 </td>
@@ -115,15 +117,15 @@ background-image: url('{{frappe.get_url()}}{%if element.isDynamic %}{{element.im
         </tbody>
     </table>
     {% if element.get("isPrimaryTable", false) or settings.get("schema_version") == "1.0.0" %}
-        {% set renderAfterTableElement =  render_element(afterTableElement) %}
+        {% set renderAfterTableElement =  render_element(afterTableElement, send_to_jinja) %}
         {% if renderAfterTableElement %}<div style="position: relative; top:0px; left: 0px;">{{ renderAfterTableElement }}</div>{% endif %}
     {% endif %}
 </div>
 {%- endmacro %}
-{%- macro render_spanvalue(field, element, row) -%}
+{%- macro render_spanvalue(field, element, row, send_to_jinja) -%}
 {%- if field.is_static -%}
     {% if field.parseJinja %}
-        {{frappe.render_template(field.value, {'doc': doc, 'row': row})}}
+    {{ render_user_text(field.value, doc, row, send_to_jinja) }}
     {% else %}
         {{ _(field.value) }}
     {% endif %}
@@ -135,8 +137,9 @@ background-image: url('{{frappe.get_url()}}{%if element.isDynamic %}{{element.im
 {%- else -%}
 {{doc.get_formatted(field.fieldname)}}
 {%- endif -%}{%- endmacro -%}
-{% macro render_spantag(field, element, row = None) -%}
-{% set span_value = render_spanvalue(field, element, row) %}
+<!-- third Arg is row which is not sent outside table -->
+{% macro render_spantag(field, element, row = {}, send_to_jinja = {}) -%}
+{% set span_value = render_spanvalue(field, element, row, send_to_jinja) %}
 <span class="{% if not field.is_static and field.is_labelled %}baseSpanTag{% endif %}">
     {% if not field.is_static and field.is_labelled and span_value %}
     <span class="{% if row %}printTable{% else %}dynamicText{% endif %} label-text labelSpanTag" style="user-select:auto;{%if element.labelStyle %}{{convert_css(element.labelStyle)}}{%endif%}{%if field.labelStyle %}{{convert_css(field.labelStyle)}}{%endif%}">
@@ -152,31 +155,36 @@ background-image: url('{{frappe.get_url()}}{%if element.isDynamic %}{{element.im
     {% endif %}
 </span>
 {%- endmacro %}
-{% macro render_element(element) -%}
+{% macro render_element(element, send_to_jinja) -%}
 {% if element is iterable and (element is not string and element is not mapping) %}
 {% for object in element %}
-{{ render_element(object)}}
+{{ render_element(object, send_to_jinja)}}
 {% endfor %}
 {% elif element.type == "rectangle" %}
-{{ render_rectangle(element) }}
+{{ render_rectangle(element, send_to_jinja) }}
 {% elif element.type == "image" %}
 {{render_image(element)}}
 {% elif element.type == "table" %}
-{{render_table(element)}}
+{{render_table(element, send_to_jinja)}}
 {% elif element.type == "text" %}
 {% if element.isDynamic %}
-{{render_dynamictext(element)}}
+{{render_dynamictext(element, send_to_jinja)}}
 {% else%}
-{{render_statictext(element)}}
+{{render_statictext(element, send_to_jinja)}}
 {% endif %}
 {% elif element.type == "barcode" %}
-{{render_barcode(element)}}
+{{render_barcode(element, send_to_jinja)}}
 {% endif %}
 {%- endmacro %}
 {% macro getFontStyles(fonts) -%}{%for key, value in fonts.items()%}{{key ~ ':ital,wght@'}}{%for index, size in enumerate(value.weight)%}{%if index > 0%};{%endif%}0,{{size}}{%endfor%}{%for index, size in enumerate(value.italic)%}{%if index > 0%};{%endif%}1,{{size}}{%endfor%}{% if not loop.last %}{{'&display=swap&family='}}{%endif%}{%endfor%}{%- endmacro %}
-    {% set renderHeader = render_element(headerElement) %}
-    {% set renderBody =  render_element(bodyElement) %}
-    {% set renderFooter = render_element(footerElement) %}
+
+<!-- Don't remove this. user_generated_jinja_code tag is used as placeholder which we replace with user provided jinja template  -->
+<!-- user_generated_jinja_code -->
+<!-- end of user generated code -->
+
+    {% set renderHeader = render_element(headerElement, send_to_jinja) %}
+    {% set renderBody =  render_element(bodyElement, send_to_jinja) %}
+    {% set renderFooter = render_element(footerElement, send_to_jinja) %}
     <link rel="preconnect" href="https://fonts.gstatic.com" />
         {% if settings.printHeaderFonts %}
     {% set printHeaderFonts = getFontStyles(settings.printHeaderFonts) %}

--- a/print_designer/print_designer/page/print_designer/print_designer.js
+++ b/print_designer/print_designer/page/print_designer/print_designer.js
@@ -1,7 +1,4 @@
 frappe.pages["print-designer"].on_page_load = function (wrapper) {
-	// frappe.require("assets/frappe/js/pdf.min.js", () => {
-	// 	pdfjsLib.GlobalWorkerOptions.workerSrc = frappe.boot.assets_json['pdfjs.bundle.js'];
-	//   });
 	// hot reload in development
 	if (frappe.boot.developer_mode) {
 		frappe.hot_update = frappe.hot_update || [];

--- a/print_designer/public/js/print_designer/App.vue
+++ b/print_designer/public/js/print_designer/App.vue
@@ -63,9 +63,6 @@ const toolbarClasses = computed(() => {
 
 useAttachKeyBindings();
 onMounted(() => {
-	frappe.require("assets/print_designer/js/pdf.min.js", () => {
-		pdfjsLib.GlobalWorkerOptions.workerSrc = frappe.boot.assets_json["pdf.worker.bundle.js"];
-	});
 	MainStore.printDesignName = props.print_format_name;
 	fetchMeta();
 	const screen_stylesheet = document.createElement("style");

--- a/print_designer/public/js/print_designer/components/layout/AppBarcodePreviewModal.vue
+++ b/print_designer/public/js/print_designer/components/layout/AppBarcodePreviewModal.vue
@@ -152,6 +152,33 @@ const fd = {
 		},
 	}
 
+const parseJinja = async () => {
+	let value = props.fieldnames[0].value;
+	try {
+		// call render_user_text_withdoc method using frappe.call and return the result
+		let result = await frappe.call({
+			method: "print_designer.print_designer.page.print_designer.print_designer.render_user_text_withdoc",
+			args: {
+				string: value,
+				doctype: MainStore.doctype,
+				docname: MainStore.currentDoc,
+				send_to_jinja: MainStore.mainParsedJinjaData || {},
+			},
+		})
+		return result.message;
+	} catch (error) {
+		console.error("Error in Jinja Template\n", { value_string: content.value, error });
+		frappe.show_alert(
+			{
+				message: "Unable Render Jinja Template. Please Check Console",
+				indicator: "red",
+			},
+			5
+		);
+		return value
+	}
+}
+
 const setBarcode = async () => {
 	try {
 		const options = {
@@ -166,7 +193,7 @@ const setBarcode = async () => {
 		let value = props.fieldnames[0].value;
 		if (props.fieldnames[0].parseJinja && value != "") {
 				try {
-					value = frappe.render(value, {doc: MainStore.docData})
+					value = await parseJinja()
 				} catch (error) {
 					console.error("Error in Jinja Template\n", { value_string: value, error });
 					frappe.show_alert(
@@ -193,7 +220,7 @@ const setBarcode = async () => {
 	}
 };
 
-watch(() => [props.fieldnames, barcodeFormat.value], () => setBarcode(), { deep: true, immediate: true });
+watch(() => [props.fieldnames, barcodeFormat.value, MainStore.mainParsedJinjaData], () => setBarcode(), { deep: true, immediate: true });
 
 const parentField = ref("");
 const setParentField = (value) => {

--- a/print_designer/public/js/print_designer/components/layout/AppCanvas.vue
+++ b/print_designer/public/js/print_designer/components/layout/AppCanvas.vue
@@ -50,6 +50,9 @@
 				v-if="!!MainStore.openImageModal"
 				:openImageModal="MainStore.openImageModal"
 			/>
+			<AppUserProvidedJinjaModal
+				v-if="!!MainStore.openJinjaModal"
+			/>
 		</div>
 		<AppPreviewPdf v-if="MainStore.mode == 'preview'" />
 	</div>
@@ -64,6 +67,7 @@ import AppPdfSetup from "./AppPdfSetup.vue";
 import AppPreviewPdf from "./AppPreviewPdf.vue";
 import AppWidthHeightModal from "./AppWidthHeightModal.vue";
 import AppDynamicTextModal from "./AppDynamicTextModal.vue";
+import AppUserProvidedJinjaModal from "./AppUserProvidedJinjaModal.vue";
 import AppBarcodeModal from "./AppBarcodeModal.vue";
 import AppImageModal from "./AppImageModal.vue";
 import { watch, watchEffect, onMounted, nextTick } from "vue";
@@ -518,6 +522,20 @@ watchEffect(() => {
 			],
 		]);
 	}
+});
+
+watch(() => [MainStore.userProvidedJinja, MainStore.doctype, MainStore.currentDoc], async () => {
+	if ([MainStore.currentDoc, MainStore.currentDoc].includes(null)) return;
+	let result = await frappe.call({
+		method: "print_designer.print_designer.page.print_designer.print_designer.get_data_from_main_template",
+		args: {
+			string: MainStore.userProvidedJinja,
+			doctype: MainStore.doctype,
+			docname: MainStore.currentDoc,
+			settings: {},
+		},
+	})
+	MainStore.mainParsedJinjaData = result.message;
 });
 </script>
 <style deep lang="scss">

--- a/print_designer/public/js/print_designer/components/layout/AppCodeEditor.vue
+++ b/print_designer/public/js/print_designer/components/layout/AppCodeEditor.vue
@@ -1,0 +1,121 @@
+<template>
+	<div
+		class="editor"
+		:style="{
+			height: height,
+		}">
+		<h3 class="mb-1 text-xs font-bold uppercase text-gray-600" v-if="label">
+			{{ label }}
+		</h3>
+		<div ref="editor" class="border border-gray-200 dark:border-zinc-800" />
+	</div>
+</template>
+<script setup>
+import { useDark } from "@vueuse/core";
+import ace from "ace-builds";
+import "ace-builds/src-noconflict/theme-chrome";
+import "ace-builds/src-noconflict/theme-twilight";
+import { onMounted, ref, watch } from "vue";
+const isDark = useDark();
+
+const props = defineProps({
+	modelValue: {
+		type: [Object, String, Array],
+	},
+	type: {
+		type: String,
+        Options: ["HTML", "CSS", "JavaScript", "Python", "JSON"],
+		default: "JSON",
+	},
+	label: {
+		type: String,
+		default: "",
+	},
+	readonly: {
+		type: Boolean,
+		default: false,
+	},
+	height: {
+		type: String,
+		default: "200px",
+	},
+	showLineNumbers: {
+		type: Boolean,
+		default: false,
+	},
+});
+
+const emit = defineEmits(["update:modelValue"]);
+
+const editor = ref(null);
+onMounted(() => {
+	let initialValue = props.modelValue;
+	const aceEditor = ace.edit(editor.value || "");
+	aceEditor.setReadOnly(props.readonly);
+	aceEditor.setOptions({
+		fontSize: "12px",
+		useWorker: false,
+		showGutter: props.showLineNumbers,
+	});
+	if (props.type === "CSS") {
+		import("ace-builds/src-noconflict/mode-css").then(() => {
+			aceEditor.session.setMode("ace/mode/css");
+		});
+	} else if (props.type === "JavaScript") {
+		import("ace-builds/src-noconflict/mode-javascript").then(() => {
+			aceEditor.session.setMode("ace/mode/javascript");
+		});
+	} else if (props.type === "Python") {
+		import("ace-builds/src-noconflict/mode-python").then(() => {
+			aceEditor.session.setMode("ace/mode/python");
+		});
+	} else if (props.type === "JSON") {
+		import("ace-builds/src-noconflict/mode-json").then(() => {
+			aceEditor.session.setMode("ace/mode/json");
+		});
+		// check if initial value is valid json convert it to string
+		try {
+			initialValue = JSON.stringify(initialValue, null, 2);
+		} catch (e) {
+			// do nothing
+		}
+	} else {
+		import("ace-builds/src-noconflict/mode-html").then(() => {
+			aceEditor.session.setMode("ace/mode/html");
+		});
+	}
+	emit("update:aceEditor", aceEditor);
+	watch(
+		isDark,
+		() => {
+			aceEditor.setTheme(isDark.value ? "ace/theme/twilight" : "ace/theme/chrome");
+		},
+		{ immediate: true }
+	);
+
+	watch(
+		() => props.modelValue,
+		() => {
+			let value = props.modelValue;
+			if (props.type === "JSON") {
+				value = JSON.stringify(value, null, 2);
+			}
+			aceEditor.setValue(value);
+			aceEditor.clearSelection();
+			aceEditor.focus();
+		},
+		{ immediate: true }
+	);
+});
+</script>
+<style scoped>
+.editor .ace_editor {
+	height: calc(94vh - 200px);
+	width: 100%;
+	border-radius: 5px;
+	overscroll-behavior: none;
+}
+.editor :deep(.ace_scrollbar-h) {
+	display: none;
+}
+</style>

--- a/print_designer/public/js/print_designer/components/layout/AppPropertiesPanel.vue
+++ b/print_designer/public/js/print_designer/components/layout/AppPropertiesPanel.vue
@@ -41,6 +41,13 @@
 				Save
 			</button>
 		</div>
+		<div class="secondary-actions">
+			<button
+					class="btn btn-sm add-data-button"
+					@click="(event) => MainStore.openJinjaModal = true">
+					Manage Custom Data
+			</button>
+		</div>
 		<AppPropertiesPanelSection
 			v-for="section in MainStore.propertiesPanel"
 			:section="section"
@@ -94,6 +101,14 @@ onMounted(() => createPropertiesPanel());
 				margin: 2px 10px 2px 0px;
 				font-size: 16px;
 			}
+		}
+	}
+	.secondary-actions {
+		@extend .primary-actions;
+		background-color: var(--bg-color);
+		.add-data-button {
+			flex: 1;
+			background-color: var(--subtle-fg);
 		}
 	}
 	.text-type-container,

--- a/print_designer/public/js/print_designer/components/layout/AppUserProvidedJinjaModal.vue
+++ b/print_designer/public/js/print_designer/components/layout/AppUserProvidedJinjaModal.vue
@@ -1,0 +1,61 @@
+<template>
+	<AppModal
+		v-bind="{ size }"
+		:backdrop="true"
+		:isDraggable="false"
+		@cancelClick="cancelClick"
+		@primaryClick="primaryClick"
+	>
+		<template #title>
+			<span>User Provided Jinja</span>
+		</template>
+		<template #body>
+			<AppCodeEditor
+					:modelValue="MainStore.userProvidedJinja"
+					@update:aceEditor="updateEditor"
+					v-bind="{ aceEditor }"
+					type="HTML"
+					class="flex-1"
+					height="auto"
+					:show-line-numbers="true"></AppCodeEditor>
+		</template>
+	</AppModal>
+</template>
+<script setup>
+import { ref } from "vue";
+import { useMainStore } from "../../store/MainStore";
+import AppModal from "./AppModal.vue";
+import AppCodeEditor from "./AppCodeEditor.vue";
+const MainStore = useMainStore();
+
+const size = {
+	width: "75vw",
+	height: "calc(94vh - 90px)",
+	left: "6vw",
+	top: "3vh",
+};
+
+const aceEditor = ref(null);
+
+const updateEditor = (value) => {
+	aceEditor.value = value;
+};
+
+const primaryClick = async (e) => {
+	MainStore.openJinjaModal = false;
+	try {
+			let value = aceEditor.value.getValue();
+			
+			if (value === MainStore.userProvidedJinja) return;
+
+			MainStore.userProvidedJinja = value;
+	} catch (e) {
+		// do nothing
+	}
+};
+const cancelClick = () => {
+	MainStore.openJinjaModal = false
+	};
+</script>
+<style scoped lang="scss">
+</style>

--- a/print_designer/public/js/print_designer/store/ElementStore.js
+++ b/print_designer/public/js/print_designer/store/ElementStore.js
@@ -287,6 +287,7 @@ export const useElementStore = defineStore("ElementStore", {
 				printHeaderFonts: MainStore.printHeaderFonts,
 				printFooterFonts: MainStore.printFooterFonts,
 				printBodyFonts: MainStore.printBodyFonts,
+				userProvidedJinja: MainStore.userProvidedJinja,
 				schema_version: MainStore.schema_version,
 			};
 			await frappe.dom.freeze();

--- a/print_designer/public/js/print_designer/store/MainStore.js
+++ b/print_designer/public/js/print_designer/store/MainStore.js
@@ -48,6 +48,9 @@ export const useMainStore = defineStore("MainStore", {
 		openImageModal: null,
 		openBarcodeModal: null,
 		openTableColumnModal: null,
+		openJinjaModal: false,
+		mainParsedJinjaData: "",
+		userProvidedJinja: "",
 		frappeControls: {
 			documentControl: null,
 			tableControl: null,

--- a/print_designer/public/js/print_designer/store/fetchMetaAndData.js
+++ b/print_designer/public/js/print_designer/store/fetchMetaAndData.js
@@ -115,56 +115,60 @@ export const fetchDoc = async (id = null) => {
 				}
 			});
 			MainStore.docData = doc;
-			await frappe.dom.freeze();
-			MainStore.dynamicData.forEach(async (el) => {
-				if (el.is_static) return;
-				let value = el.parentField
-					? await getValue(el.doctype, MainStore.docData[el.parentField], el.fieldname)
-					: el.tableName
-					? frappe.format(
-							MainStore.docData[el.tableName][0][el.fieldname],
-							{ fieldtype: el.fieldtype, options: el.options },
-							{ inline: true },
-							MainStore.docData
-					  )
-					: frappe.format(
-							MainStore.docData[el.fieldname],
-							{ fieldtype: el.fieldtype, options: el.options },
-							{ inline: true },
-							MainStore.docData
-					  );
-				if (typeof value == "string" && value.startsWith("<svg")) {
-					value.match(new RegExp(`data-barcode-value="(.*?)">`));
-					value = result[1];
-				};
-				if (!value) {
-					if (["Image, Attach Image"].indexOf(el.fieldtype) != -1) {
-						value = null;
-					} else {
-						switch (el.fieldname) {
-							case "page":
-								value = "0";
-								break;
-							case "topage":
-								value = "999";
-								break;
-							case "date":
-								value = frappe.datetime.now_date();
-								break;
-							case "time":
-								value = frappe.datetime.now_time();
-								break;
-							default:
-								value = `{{ ${el.parentField ? el.parentField + "." : ""}${
-									el.fieldname
-								} }}`;
-						}
-					}
-				}
-				el.value = value;
-			});
-			await frappe.dom.unfreeze();
 		},
 		{ immediate: true }
 	);
+
+	watch(() => MainStore.docData, async() => {
+		if (!Object.keys(MainStore.docData).length) return;
+		await frappe.dom.freeze();
+		MainStore.dynamicData.forEach(async (el) => {
+			if (el.is_static) return;
+			let value = el.parentField
+				? await getValue(el.doctype, MainStore.docData[el.parentField], el.fieldname)
+				: el.tableName
+				? frappe.format(
+						MainStore.docData[el.tableName][0][el.fieldname],
+						{ fieldtype: el.fieldtype, options: el.options },
+						{ inline: true },
+						MainStore.docData
+				  )
+				: frappe.format(
+						MainStore.docData[el.fieldname],
+						{ fieldtype: el.fieldtype, options: el.options },
+						{ inline: true },
+						MainStore.docData
+				  );
+			if (typeof value == "string" && value.startsWith("<svg")) {
+				value.match(new RegExp(`data-barcode-value="(.*?)">`));
+				value = result[1];
+			}
+			if (!value) {
+				if (["Image, Attach Image"].indexOf(el.fieldtype) != -1) {
+					value = null;
+				} else {
+					switch (el.fieldname) {
+						case "page":
+							value = "0";
+							break;
+						case "topage":
+							value = "999";
+							break;
+						case "date":
+							value = frappe.datetime.now_date();
+							break;
+						case "time":
+							value = frappe.datetime.now_time();
+							break;
+						default:
+							value = `{{ ${el.parentField ? el.parentField + "." : ""}${
+								el.fieldname
+							} }}`;
+					}
+				}
+			}
+			el.value = value;
+		});
+		await frappe.dom.unfreeze();
+	});
 };


### PR DESCRIPTION
feat: add custom data using jinja
Reason for adding this feature:
- to allow users to add custom data to the template using jinja
- It is not ideal to fetch data for every field in the template when it is shared at template level
- This feature allows users to add custom data at the template level using jinja

How to use this feature:
- Add custom template by clicking `Manage Custom Data` using print_designer
- on the last line make dictionary of data you want to send to template
- make sure to use `send_to_jinja` variable name.
    like `{%- set send_to_jinja = {'key_to_access_in_template': 'value'} -%}`

Example:
Code shared below will make `status` and `custom_var` available in the template
```
{% set status = doc.status %}
{% set custom_var = "This is Custom Text Saved in Custom Variable" %}
{% set send_to_jinja = {"status": status, "custom_var": custom_var} %}
```

https://github.com/frappe/print_designer/assets/39730881/65c52f05-8c4b-4dc6-b8f1-615695ebfe72


misc: removed pdfjs from print_designer ui as it is no longer used.