### PR TITLE
fix: patch utils to run on rectangle childrens

### DIFF
--- a/print_designer/patches.txt
+++ b/print_designer/patches.txt
@@ -2,3 +2,4 @@ print_designer.patches.update_white_space_property
 print_designer.patches.introduce_barcode
 print_designer.patches.introduce_jinja
 print_designer.patches.introduce_schema_versioning
+print_designer.patches.rerun_introduce_jinja

--- a/print_designer/patches/patch_utils.py
+++ b/print_designer/patches/patch_utils.py
@@ -143,6 +143,16 @@ def patch_elements(
         callback = callbacks
     for element in data:
         if element.get("type") not in types:
+            if element.get("type") == "rectangle":
+                childrens = (
+                    frappe.json.loads(element.get("childrens", "[]"))
+                    if isinstance(element.get("childrens"), str)
+                    else element.get("childrens")
+                )
+                if len(childrens) > 0:
+                    element["childrens"] = patch_elements(
+                        data=childrens, callbacks=callbacks, types=types
+                    )
             continue
         if callback:
             callback(element)

--- a/print_designer/patches/rerun_introduce_jinja.py
+++ b/print_designer/patches/rerun_introduce_jinja.py
@@ -1,0 +1,16 @@
+import frappe
+from print_designer.patches.patch_utils import patch_formats
+def execute():
+	""" Rerun patch due to bug in patch utils """
+	def element_callback(el):
+		if el.get("type") == "text" and not el.get("isDynamic"):
+			if not "parseJinja" in el:
+				el["parseJinja"] = False
+	def dynamic_content_callback(el):
+		if el.get("is_static", False):
+			if not "parseJinja" in el:
+				el["parseJinja"] = False
+	patch_formats({
+		"element": element_callback,
+		"dynamic_content": dynamic_content_callback
+	}, types=["text", "table", "barcode"])


### PR DESCRIPTION
when rectangle is not in types list argument, it will not run on childrens.
however, it can have childrens that have one of specified types.
so run on patch_elements childrens when rectangle is not in types list.

also added introduce_jinja patch again as it wasn't applied on childrens