### PR TITLE
fix(misc): don't save format with missing table

### DIFF
--- a/print_designer/public/js/print_designer/store/ElementStore.js
+++ b/print_designer/public/js/print_designer/store/ElementStore.js
@@ -65,6 +65,14 @@ export const useElementStore = defineStore("ElementStore", {
 			const afterTableElements = [];
 			const footerElements = [];
 			let tableElement = this.Elements.filter((el) => el.type == "table");
+			if (tableElement.some((el) => el.table == null)){
+				let message = __("You have Empty Table. Please add table fields or remove table.")
+				frappe.show_alert({
+					message: message,
+					indicator: "red",
+				}, 5);
+				return;
+			}
 			let isOverlapping = false;
 			if (tableElement.length == 1 && MainStore.isHeaderFooterAuto) {
 				this.Elements.forEach((element) => {


### PR DESCRIPTION
If there is empty table print format breaks and most likely it is user error so when user tries to save format with empty table we just show the error. and prevent saving.

closes #112 