### PR TITLE
feat(minor): allow renaming print format from pd

### DIFF
--- a/print_designer/public/js/print_designer/components/layout/AppDynamicPreviewModal.vue
+++ b/print_designer/public/js/print_designer/components/layout/AppDynamicPreviewModal.vue
@@ -142,6 +142,7 @@
 <script setup>
 import { ref, nextTick, onMounted, onUnmounted, watchPostEffect } from "vue";
 import { useMainStore } from "../../store/MainStore";
+import { selectElementContents } from "../../utils";
 const MainStore = useMainStore();
 const props = defineProps({
 	fieldnames: {
@@ -208,14 +209,6 @@ defineExpose({ parentField, setParentField, selectedEl, setSelectedEl, label, se
 const handleClick = (event, field, index) => {
 	selectedEl.value = { index, field };
 	parentField.value = field.parentField;
-};
-
-const selectElementContents = (el) => {
-	const range = document.createRange();
-	range.selectNodeContents(el);
-	const sel = window.getSelection();
-	sel.removeAllRanges();
-	sel.addRange(range);
 };
 
 const handleDblClick = (event, field) => {

--- a/print_designer/public/js/print_designer/components/layout/AppHeader.vue
+++ b/print_designer/public/js/print_designer/components/layout/AppHeader.vue
@@ -7,7 +7,15 @@
 				src="/assets/print_designer/images/print-designer-logo.svg"
 			/>
 		</a>
-		<h3 class="title">{{ print_format_name }}</h3>
+		<h3
+			class="title"
+			:contenteditable="contenteditable"
+			@keydown="handleKeyDown"
+			@click="handleCLick"
+			@blur="editNameOnBlur"
+		>
+			{{ print_format_name }}
+		</h3>
 		<span class="indicator-pill no-indicator-dot ellipsis gray">Beta</span>
 		<button class="btn btn-sm btn-default exit-btn" @click="goToLastPage">
 			<svg
@@ -24,6 +32,71 @@
 	</div>
 </template>
 <script setup>
+import { ref } from "vue";
+import { useMainStore } from "../../store/MainStore";
+import { selectElementContents } from "../../utils";
+
+const MainStore = useMainStore();
+
+const contenteditable = ref(false);
+
+const handleCLick = (e) => {
+	if (!contenteditable.value) {
+		contenteditable.value = true;
+	}
+	setTimeout(function () {
+		if (document.activeElement !== e.target) {
+			e.target.focus();
+			selectElementContents(e.target);
+		} else {
+			e.target.focus();
+		}
+	}, 0);
+};
+
+const editNameOnBlur = (e) => {
+	contenteditable.value = false;
+	const new_name = e.target.innerText.trim();
+	const doctype = "Print Format";
+	const docname = MainStore.printDesignName;
+	if (new_name === "" || new_name === docname) {
+		e.target.innerText = docname;
+		return;
+	}
+	if (new_name === docname) return;
+
+	const callback = (r, rt) => {
+		if (!r.exc) {
+			$(document).trigger("rename", [doctype, docname, r.message || new_name]);
+			if (locals[doctype] && locals[doctype][docname]) delete locals[doctype][docname];
+			frappe.set_route();
+			frappe.set_route("print-designer", new_name);
+		}
+	};
+
+	frappe.call({
+		method: "frappe.rename_doc",
+		freeze: true,
+		freeze_message: "Renaming Format Name...",
+		args: {
+			doctype: doctype,
+			old: docname,
+			new: new_name,
+			merge: false,
+		},
+		callback: callback,
+	});
+};
+
+const handleKeyDown = (e) => {
+	if (["Escape", "Enter", "Tab"].indexOf(e.key) != -1) {
+		e.target.blur();
+	}
+	if (e.key == "Tab") {
+		e.preventDefault();
+	}
+};
+
 const props = defineProps({
 	print_format_name: String,
 });
@@ -62,6 +135,7 @@ const goToLastPage = () => {
 		letter-spacing: 0.015em;
 		margin-bottom: 0;
 		user-select: none;
+		cursor: text;
 	}
 
 	.exit-btn {
@@ -70,6 +144,19 @@ const goToLastPage = () => {
 		align-items: center;
 		gap: 4px;
 		padding: 2px 8px;
+	}
+
+	[contenteditable] {
+		outline: none;
+		padding: 6px 8px;
+		&:hover {
+			padding-bottom: 5px;
+			border-bottom: 1px solid #d5c291;
+		}
+		&:focus {
+			border-bottom: 1px solid var(--primary);
+			padding-bottom: 5px;
+		}
 	}
 }
 </style>

--- a/print_designer/public/js/print_designer/utils.js
+++ b/print_designer/public/js/print_designer/utils.js
@@ -752,3 +752,11 @@ export const handlePrintFonts = (element, printFonts) => {
 		}
 	});
 };
+
+export const selectElementContents = (el) => {
+	const range = document.createRange();
+	range.selectNodeContents(el);
+	const sel = window.getSelection();
+	sel.removeAllRanges();
+	sel.addRange(range);
+};


### PR DESCRIPTION
previously, to rename print format you had to leave print designer go to the "Print Format" doctype and rename from there. Now i have added a option when you click on name of print format in print designer and you can rename it.

misc: moved selectElementContents to utils.js

fixes: #105 

https://github.com/frappe/print_designer/assets/39730881/270704c2-e8e4-47ad-a784-5e645f724d39

