### PR TITLE
fix: print format set standard to Yes

### DIFF
--- a/print_designer/hooks.py
+++ b/print_designer/hooks.py
@@ -77,6 +77,11 @@ before_uninstall = "print_designer.uninstall.before_uninstall"
 # after_uninstall = "print_designer.uninstall.after_uninstall"
 
 # ------------
+# After Migrate
+after_migrate = ["print_designer.migrate.after_migrate"]
+
+
+# ------------
 # PDF
 # ------------
 

--- a/print_designer/migrate.py
+++ b/print_designer/migrate.py
@@ -1,0 +1,14 @@
+import click
+import frappe
+
+
+def after_migrate():
+	if bool(frappe.db.exists("DocField", {"parent": "Print Format", "fieldname": "print_from_file"})):
+		frappe.modules.patch_handler.run_single(
+			"print_designer.patches.set_print_format_print_from_file_as_false"
+		)
+	else:
+		click.secho(
+			"Please Update to Latest Framework Version to use Standard Print Formats created using Print Designer",
+			fg="yellow",
+		)

--- a/print_designer/patches/set_print_format_print_from_file_as_false.py
+++ b/print_designer/patches/set_print_format_print_from_file_as_false.py
@@ -1,0 +1,13 @@
+import frappe
+
+
+def execute():
+	"""Update print_from_file to 0 for all print formats created with print_designer."""
+	# This is called from after_migrate hook, because we need to run this conditionally
+	print_formats = frappe.get_all(
+		"Print Format",
+		filters={"print_designer": 1, "Standard": "Yes"},
+		fields=["name"],
+	)
+	for pf in print_formats:
+		frappe.db.set_value("Print Format", pf.name, "print_from_file", 0)

--- a/print_designer/print_designer/client_scripts/print_format.js
+++ b/print_designer/print_designer/client_scripts/print_format.js
@@ -2,6 +2,11 @@ frappe.ui.form.on("Print Format", {
 	refresh: function (frm) {
 		frm.trigger("render_buttons");
 	},
+	standard: function (frm) {
+		if (frm.doc.standard == "Yes" && frm.doc.print_designer == 1) {
+			frm.set_value("print_from_file", 0);
+		}
+	},
 	render_buttons: function (frm) {
 		frm.page.clear_inner_toolbar();
 		if (!frm.is_new()) {


### PR DESCRIPTION
when Standard is set to Yes, JSON file for print format is created. however, logic for print format in framework assumed that when standard is set to Yes HTML file should be loaded from disk. which is incorrect as HTML file is not required when standard is set to Yes for print designer.

fix for this is raised in Frappe framework.
ref: https://github.com/frappe/frappe/pull/24694

This PR contains client script for Print Designer and patch for print designer formats.


This closes #118 