### PR TITLE
fix: pos print and added trigger_print

### DIFF
--- a/print_designer/hooks.py
+++ b/print_designer/hooks.py
@@ -26,7 +26,10 @@ app_license = "AGPLv3"
 # webform_include_css = {"doctype": "public/css/doctype.css"}
 
 # include js in page
-page_js = {"print": "print_designer/client_scripts/print.js"}
+page_js = {
+	"print": "print_designer/client_scripts/print.js",
+	"point-of-sale": "print_designer/client_scripts/point_of_sale.js",
+}
 
 # include js in doctype views
 doctype_js = {"Print Format": "print_designer/client_scripts/print_format.js"}

--- a/print_designer/print_designer/client_scripts/point_of_sale.js
+++ b/print_designer/print_designer/client_scripts/point_of_sale.js
@@ -1,0 +1,42 @@
+// overrides the print util function that is used in the point of sale page.
+// we should ideally change util function in framework to extend it. this is workaround until that.
+frappe.utils.print = (doctype, docname, print_format, letterhead, lang_code) => {
+	let w;
+	if (frappe.model.get_value("Print Format", print_format, "print_designer")) {
+		w = window.open(
+			frappe.urllib.get_full_url(
+				"/app/print/" +
+					encodeURIComponent(doctype) +
+					"/" +
+					encodeURIComponent(docname) +
+					"?format=" +
+					encodeURIComponent(print_format) +
+					"&no_letterhead=0" +
+					"&trigger_print=1" +
+					(lang_code ? "&_lang=" + lang_code : "")
+			)
+		);
+	} else {
+		w = window.open(
+			frappe.urllib.get_full_url(
+				"/printview?doctype=" +
+					encodeURIComponent(doctype) +
+					"&name=" +
+					encodeURIComponent(docname) +
+					"&trigger_print=1" +
+					"&format=" +
+					encodeURIComponent(print_format) +
+					"&no_letterhead=" +
+					(letterhead ? "0" : "1") +
+					"&letterhead=" +
+					encodeURIComponent(letterhead) +
+					(lang_code ? "&_lang=" + lang_code : "")
+			)
+		);
+	}
+
+	if (!w) {
+		frappe.msgprint(__("Please enable pop-ups"));
+		return;
+	}
+};

--- a/print_designer/print_designer/client_scripts/print.js
+++ b/print_designer/print_designer/client_scripts/print.js
@@ -145,6 +145,9 @@ frappe.ui.form.PrintView = class PrintView extends frappe.ui.form.PrintView {
 				await renderPage(this.pdfDoc, pageno);
 			}
 			this.pdf_download_btn.prop("disabled", false);
+			if (frappe.route_options.trigger_print) {
+				this.printit();
+			}
 			this.print_btn.prop("disabled", false);
 		} catch (err) {
 			console.error(err);
@@ -245,6 +248,11 @@ frappe.ui.form.PrintView = class PrintView extends frappe.ui.form.PrintView {
 						setTimeout(() => {
 							iframe.focus();
 							iframe.contentWindow.print();
+							if (frappe.route_options.trigger_print) {
+								setTimeout(function () {
+									window.close();
+								}, 5000);
+							}
 						}, 1);
 					};
 				} else {


### PR DESCRIPTION
added client script to update frappe.util.print function that is used in pos. Also, added option to trigger print on print view by passing it as URL Parameter. If trigger_print=1 is passed it will close the window in 5 second after print dialog is closed. This is added to maintain current behavior.
If this causes issue we can introduce 1 more arg for closing and pass when using frappe.util.print.

Before

https://github.com/frappe/print_designer/assets/39730881/158cb590-4334-470e-a36b-a88e56e10d0f

After

https://github.com/frappe/print_designer/assets/39730881/8d838875-f003-4150-9496-a0dc201b6d39

closes #164 