### PR TITLE
fix: remove border around table container

### DIFF
--- a/print_designer/public/js/print_designer/components/base/BaseTable.vue
+++ b/print_designer/public/js/print_designer/components/base/BaseTable.vue
@@ -13,7 +13,7 @@
 		]"
 	>
 		<div
-			:style="['overflow: hidden;', widthHeightStyle(width - 2, height)]"
+			:style="['overflow: hidden;', widthHeightStyle(width, height)]"
 			@click.stop.self="
 				() => {
 					selectedColumn = null;
@@ -368,7 +368,6 @@ const handleMouseUp = (e, tablewidth) => {
 	background-color: var(--gray-300);
 }
 .table-container {
-	border: 1px solid var(--gray-400);
 	background-color: var(--gray-50);
 	.printTable {
 		border-collapse: collapse;


### PR DESCRIPTION
We check if Element is part of header / footer by checking starting postion and height. because of the border around the table container we had to leave atleast 1 px space between header and table. removed border so users can create more contected looking formats.