### PR TITLE
fix: static text only save inner text

### DIFF
--- a/print_designer/public/js/print_designer/components/base/BaseStaticText.vue
+++ b/print_designer/public/js/print_designer/components/base/BaseStaticText.vue
@@ -214,7 +214,7 @@ const handleBlur = (e) => {
 		width.value = targetRect.width + 2;
 		height.value = targetRect.height + 2;
 	}
-	content.value = DOMRef.value.firstElementChild.innerHTML;
+	content.value = DOMRef.value.firstElementChild.innerText; // This will break styled texts :(
 	MainStore.getCurrentElementsId.includes(id.value) &&
 		DOMRef.value.classList.add("active-elements");
 	contenteditable.value = false;


### PR DESCRIPTION
This will break styled text, but i think plain text is more used. 
chrome adds unnecessary tags so only saving innerText instead of innerHTML for now.

fixes #129 #221 