### PR TITLE
fix: google font url generator edge case

### DIFF
--- a/print_designer/print_designer/page/print_designer/jinja/macros/render_google_fonts.html
+++ b/print_designer/print_designer/page/print_designer/jinja/macros/render_google_fonts.html
@@ -1,4 +1,4 @@
-{% macro getFontStyles(fonts) -%}{%for key, value in fonts.items()%}{{key ~ ':ital,wght@'}}{%for index, size in enumerate(value.weight)%}{%if index > 0%};{%endif%}0,{{size}}{%endfor%}{%for index, size in enumerate(value.italic)%}{%if index > 0%};{%endif%}1,{{size}}{%endfor%}{% if not loop.last %}{{'&display=swap&family='}}{%endif%}{%endfor%}{%- endmacro %}
+{% macro getFontStyles(fonts) -%}{%for key, value in fonts.items()%}{{key ~ ':ital,wght@'}}{%for index, size in enumerate(value.weight)%}{%if index > 0%};{%endif%}0,{{size}}{%endfor%}{%for index, size in enumerate(value.italic)%}{%if index > 0 or value.weight|length != 0 %};{%endif%}1,{{size}}{%endfor%}{% if not loop.last %}{{'&display=swap&family='}}{%endif%}{%endfor%}{%- endmacro %}
 
 {% macro render_google_fonts(settings) %}
     <link rel="preconnect" href="https://fonts.gstatic.com" />


### PR DESCRIPTION
we save font details saved in json object and then we generate url from it using jinja template. there was a edge case where `;` was not being added at the end of normal weight.

incorrect https://fonts.googleapis.com/css2?family=JetBrains%20Mono:ital,wght@0,400;0,5001,400 

correct https://fonts.googleapis.com/css2?family=JetBrains%20Mono:ital,wght@0,400;0,500;1,400