### PR TITLE
fix(minor): call the framework pdf_body_html func

### DIFF
--- a/print_designer/pdf.py
+++ b/print_designer/pdf.py
@@ -6,6 +6,7 @@ import frappe
 from frappe.monitor import add_data_to_monitor
 from frappe.utils.error import log_error
 from frappe.utils.jinja_globals import is_rtl
+from frappe.utils.pdf import pdf_body_html as fw_pdf_body_html
 
 
 def pdf_header_footer_html(soup, head, content, styles, html_id, css):
@@ -82,8 +83,7 @@ def pdf_body_html(print_format, jenv, args, template):
 				return f"<h1><b>Something went wrong while rendering the print format.</b> <hr/> If you don't know what just happened, and wish to file a ticket or issue on Github <hr /> Please copy the error from <code>Error Log {error.name}</code> or ask Administrator.<hr /><h3>Error rendering print format: {error.reference_name}</h3><h4>{error.method}</h4><pre>{html.escape(error.error)}</pre>"
 			else:
 				return f"<h1><b>Something went wrong while rendering the print format.</b> <hr/> If you don't know what just happened, and wish to file a ticket or issue on Github <hr /> Please copy the error from <code>Error Log {error.name}</code> or ask Administrator.</h1>"
-
-	return template.render(args, filters={"len": len})
+	return fw_pdf_body_html(template, args)
 
 
 def is_older_schema(settings, current_version):


### PR DESCRIPTION
Instead of rendering template directly call the framework pdf_body_html function to render the html. this prevents incorrect possible source of error as shown below.

<img width="400" alt="Screenshot 2024-05-14 at 9 41 44 AM" src="https://github.com/frappe/print_designer/assets/39730881/c4ba6de7-620c-45bd-8020-2a5d5317ed77">
