### PR TITLE
fix(minor): fix html for modern browsers recursive

### DIFF
--- a/print_designer/print_designer/page/print_designer/jinja/macros/styles.html
+++ b/print_designer/print_designer/page/print_designer/jinja/macros/styles.html
@@ -87,10 +87,13 @@
         display: -webkit-flex;
         display: flex;
         border-width: 0 !important;
+        flex: auto;
     }
     .relative-column {
         border-width: 0px !important;
         border-color: transparent !important;
+        flex-direction: column;
+        flex: auto;
     }
     * {
         -webkit-box-sizing: border-box;


### PR DESCRIPTION
fixed html that was broken on modern browsers due to changes made by recursive containers PR.

## Before 
<img width="929" alt="Screenshot 2024-05-14 at 12 47 31 PM" src="https://github.com/frappe/print_designer/assets/39730881/c05b0ba6-24d3-4456-8310-bc5582c51da4">

## After
<img width="683" alt="Screenshot 2024-05-14 at 12 47 07 PM" src="https://github.com/frappe/print_designer/assets/39730881/68e75d3e-1403-4c8c-92d8-5f7a46575bf0">
