### PR TITLE
fix: patch utils for old patches

### DIFF
--- a/print_designer/patches.txt
+++ b/print_designer/patches.txt
@@ -1,3 +1,7 @@
+[pre_model_sync]
+execute:from print_designer.patches.create_custom_fields import custom_field_patch; custom_field_patch()
+
+[post_model_sync]
 print_designer.patches.update_white_space_property
 print_designer.patches.introduce_barcode
 print_designer.patches.introduce_jinja
@@ -9,5 +13,4 @@ print_designer.patches.introduce_suffix_dynamic_content
 print_designer.patches.introduce_dynamic_containers
 print_designer.patches.introduce_dynamic_height
 print_designer.patches.remove_unused_rectangle_gs_properties
-execute:from print_designer.patches.create_custom_fields import custom_field_patch; custom_field_patch()
 print_designer.patches.change_dynamic_height_variable

--- a/print_designer/patches.txt
+++ b/print_designer/patches.txt
@@ -1,5 +1,6 @@
 [pre_model_sync]
-execute:from print_designer.patches.create_custom_fields import custom_field_patch; custom_field_patch()
+print_designer.patches.introduce_dynamic_containers
+execute:from print_designer.patches.create_custom_fields import custom_field_patch; custom_field_patch() #208
 
 [post_model_sync]
 print_designer.patches.update_white_space_property
@@ -10,7 +11,6 @@ print_designer.patches.rerun_introduce_jinja
 print_designer.patches.introduce_table_alt_row_styles
 print_designer.patches.introduce_column_style
 print_designer.patches.introduce_suffix_dynamic_content
-print_designer.patches.introduce_dynamic_containers
 print_designer.patches.introduce_dynamic_height
 print_designer.patches.remove_unused_rectangle_gs_properties
 print_designer.patches.change_dynamic_height_variable

--- a/print_designer/patches/patch_utils.py
+++ b/print_designer/patches/patch_utils.py
@@ -109,10 +109,10 @@ def patch_formats(
 	for pf in print_formats:
 		print_json = pf[5] or "{}"
 		# print_designer_print_format was introduced in schema version 1.1.0 so running this on older version is not required
+		pf_doc = frappe.get_doc("Print Format", pf[0])
 		if update_print_json and not is_older_schema(
 			settings=frappe.json.loads(pf[6] or "{}"), current_version="1.1.0"
 		):
-			pf_doc = frappe.get_doc("Print Format", pf[0])
 			print_json = frappe.json.loads(print_json)
 			if print_json.get("header", None):
 				print_json["header"] = patch_elements(print_json["header"], callbacks, types)

--- a/print_designer/patches/patch_utils.py
+++ b/print_designer/patches/patch_utils.py
@@ -112,6 +112,7 @@ def patch_formats(
 		if update_print_json and not is_older_schema(
 			settings=frappe.json.loads(pf[6] or "{}"), current_version="1.1.0"
 		):
+			pf_doc = frappe.get_doc("Print Format", pf[0])
 			print_json = frappe.json.loads(print_json)
 			if print_json.get("header", None):
 				print_json["header"] = patch_elements(print_json["header"], callbacks, types)
@@ -120,8 +121,9 @@ def patch_formats(
 			if print_json.get("footer", None):
 				print_json["footer"] = patch_elements(print_json["footer"], callbacks, types)
 			print_json = frappe.json.dumps(print_json)
+			pf_doc.update({"print_designer_print_format": print_json})
 
-		updated_doc = frappe.get_doc("Print Format", pf[0]).update(
+		pf_doc.update(
 			{
 				"print_designer_header": frappe.json.dumps(
 					patch_elements(frappe.json.loads(pf[1] or "[]"), callbacks, types)
@@ -135,11 +137,10 @@ def patch_formats(
 				"print_designer_footer": frappe.json.dumps(
 					patch_elements(frappe.json.loads(pf[4] or "[]"), callbacks, types)
 				),
-				"print_designer_print_format": print_json,
 			}
 		)
 		if save:
-			updated_doc.save(ignore_permissions=True, ignore_version=False)
+			pf_doc.save(ignore_permissions=True, ignore_version=False)
 
 
 def patch_elements(


### PR DESCRIPTION
As patch utils are used by all patches there isn't print_designer_print_format field when old patches are running and there is no need to try and update it.

Also, moved custom_field_patch in pre_model_sync