### PR TITLE
Raw Print

### DIFF
--- a/print_designer/custom_fields.py
+++ b/print_designer/custom_fields.py
@@ -58,5 +58,15 @@ CUSTOM_FIELDS = {
 			"default": "print_designer",
 			"insert_after": "standard",
 		},
+	],
+	"Print Settings": [
+		{
+			"default": "0",
+			"fieldname": "enable_raw_cmd_print_designer",
+			"fieldtype": "Check",
+			"hidden": 0,
+			"label": "Enable Raw CMD for Print Designer",
+            "insert_after": "enable_raw_printing",
+		},
 	]
 }

--- a/print_designer/hooks.py
+++ b/print_designer/hooks.py
@@ -158,9 +158,9 @@ pd_standard_format_folder = "default_templates"
 # Overriding Methods
 # ------------------------------
 #
-# override_whitelisted_methods = {
-# 	"frappe.desk.doctype.event.event.get_events": "print_designer.event.get_events"
-# }
+override_whitelisted_methods = {
+	"frappe.www.printview.get_rendered_raw_commands": "print_designer.pdf.get_rendered_raw_commands"
+}
 #
 # each overriding function accepts a `data` argument;
 # generated from the base implementation of the doctype dashboard,

--- a/print_designer/pdf.py
+++ b/print_designer/pdf.py
@@ -142,5 +142,4 @@ def raw_pd_render_template(print_format, jenv, args):
 			htmlBodyTemplateStr = template.render(args, filters={"len": len})
 			htmlRawCmdList.append({'type':'html','data':htmlBodyTemplateStr})
 			htmlRawCmdList.append({'type':'raw_cmd','data':rawCmdAfterEle})
-			htmlStr += htmlBodyTemplateStr 		# To in show print preview
-	return  htmlStr
+	return  htmlRawCmdList

--- a/print_designer/pdf.py
+++ b/print_designer/pdf.py
@@ -147,10 +147,10 @@ def raw_pd_render_template(print_format, jenv, args):
 			rawCmdAfterEle = element.get('childrens')[0].get('rawCmdAfterEle', ' ')
 
 			args.update({"element": [element]})
-			htmlRawCmdList.append({'type':'raw_cmd','data':rawCmdBeforeEle})
+			htmlRawCmdList.append({'type':'raw_cmd','data':fr'{rawCmdBeforeEle}'})
 			htmlBodyTemplateStr = template.render(args, filters={"len": len})
 			htmlRawCmdList.append({'type':'html','data':htmlBodyTemplateStr})
-			htmlRawCmdList.append({'type':'raw_cmd','data':rawCmdAfterEle})
+			htmlRawCmdList.append({'type':'raw_cmd','data':fr'{rawCmdAfterEle}'})
 	return  htmlRawCmdList
 
 

--- a/print_designer/print_designer/client_scripts/print.js
+++ b/print_designer/print_designer/client_scripts/print.js
@@ -232,7 +232,8 @@ frappe.ui.form.PrintView = class PrintView extends frappe.ui.form.PrintView {
 			super.printit();
 			return;
 		}
-		if (this.get_print_format().print_designer) {
+		let pdState = this.isPDRawPrintEnable(this.get_print_format())
+		if (this.get_print_format().print_designer && !pdState) {
 			if (!this.pdfDoc) return;
 			this.pdfDoc.getData().then((arrBuff) => {
 				let file = new Blob([arrBuff], { type: "application/pdf" });
@@ -276,7 +277,8 @@ frappe.ui.form.PrintView = class PrintView extends frappe.ui.form.PrintView {
 	}
 	preview() {
 		let print_format = this.get_print_format();
-		if (print_format.print_designer && print_format.print_designer_body) {
+		let rawprintPD = this.isPDRawPrintEnable(print_format)
+		if (print_format.print_designer && print_format.print_designer_body && !rawprintPD) {
 			this.inner_msg.hide();
 			this.print_wrapper.find(".print-preview-wrapper").hide();
 			this.print_wrapper.find(".preview-beta-wrapper").hide();

--- a/print_designer/print_designer/client_scripts/print.js
+++ b/print_designer/print_designer/client_scripts/print.js
@@ -276,7 +276,7 @@ frappe.ui.form.PrintView = class PrintView extends frappe.ui.form.PrintView {
 							let data = ['^XA\n'];
 							let rawCmdArray = out.raw_commands
 							for(let rawElement of rawCmdArray){
-								if (rawElement.startsWith("^")) {
+								if (rawElement.type == "raw_cmd") {
 									data.push(rawElement)
 									continue
 								} else {

--- a/print_designer/print_designer/client_scripts/print.js
+++ b/print_designer/print_designer/client_scripts/print.js
@@ -302,7 +302,7 @@ frappe.ui.form.PrintView = class PrintView extends frappe.ui.form.PrintView {
 							let rawCmdArray = out.raw_commands
 							for(let rawElement of rawCmdArray){
 								if (rawElement.type == "raw_cmd") {
-									data.push(rawElement.data)
+									data.push({type: 'raw', format: 'command', flavor: 'plain', data: rawElement.data})
 								} else {
 									let htmlObj = { type: 'raw', format: 'html', flavor: 'plain', data: rawElement.data, options: options }
 									data.push(htmlObj)

--- a/print_designer/print_designer/client_scripts/print.js
+++ b/print_designer/print_designer/client_scripts/print.js
@@ -331,17 +331,17 @@ frappe.ui.form.PrintView = class PrintView extends frappe.ui.form.PrintView {
 			},
 			callback: function (r) {
 				if (!r.exc) {
-					//Commenting this Code as of now....
-					// let breakTag = '<p>-------------------------------------</p>'
-					// let previewHtml = ""
-					// for(let element of r.message['html']){
-					// 	if( element.type == "html"){
-					// 		previewHtml += element.data
-					// 	} else{
-					// 		previewHtml += breakTag
-					// 	}
-					// }
-					// r.message['html'] = previewHtml
+					// Commenting this Code as of now....
+					let breakTag = '<p style="text-align:center;">-------------------------------------</p>'
+					let previewHtml = ""
+					for(let element of r.message['html']){
+						if( element.type == "html"){
+							previewHtml += element.data
+						} else{
+							previewHtml += breakTag
+						}
+					}
+					r.message['html'] = previewHtml
 					callback(r.message);
 				}
 			},

--- a/print_designer/print_designer/client_scripts/print.js
+++ b/print_designer/print_designer/client_scripts/print.js
@@ -273,6 +273,30 @@ frappe.ui.form.PrintView = class PrintView extends frappe.ui.form.PrintView {
 						.qz_connect()
 						.then(function () {
 							let printer_map = me.get_mapped_printer()[0];
+							let print_designer_settings = me.get_print_format().print_designer_settings
+							let options = {}
+
+							if (print_designer_settings == undefined){
+								frappe.show_alert(
+									{
+										message: __("Print Format"),
+										subtitle: __(
+											"Please select the correct print format."
+										),
+										indicator: "warning",
+									},
+									14
+								);
+							}
+							print_designer_settings = JSON.parse(print_designer_settings)
+							options = {
+									language: 'ESCPOS',
+									x: print_designer_settings.page.marginTop,
+									y: print_designer_settings.page.marginLeft,
+									dotDensity: "double",
+									pageWidth: print_designer_settings.page.width,
+									pageHeight: print_designer_settings.page.height
+							}
 
 							let data = [];
 							let rawCmdArray = out.raw_commands
@@ -280,7 +304,7 @@ frappe.ui.form.PrintView = class PrintView extends frappe.ui.form.PrintView {
 								if (rawElement.type == "raw_cmd") {
 									data.push(rawElement.data)
 								} else {
-									let htmlObj = { type: 'raw', format: 'html', flavor: 'plain', data: rawElement.data, options: {language: 'ESCPOS'} }
+									let htmlObj = { type: 'raw', format: 'html', flavor: 'plain', data: rawElement.data, options: options }
 									data.push(htmlObj)
 									
 								}

--- a/print_designer/print_designer/page/print_designer/jinja/macros/render.html
+++ b/print_designer/print_designer/page/print_designer/jinja/macros/render.html
@@ -1,9 +1,18 @@
 {% from 'print_designer/page/print_designer/jinja/macros/relative_containers.html' import relative_containers with context %}
 
-{% macro render(elements, send_to_jinja) -%}
+{% macro render(elements, send_to_jinja, rawEleBefore, rawEleAfter) -%}
     {% if element is iterable and (element is not string and element is not mapping) %}
+    
             {% for object in elements %}
+                {% if rawEleBefore %}
+                    <p style="text-align: center;"> ---------------------------------------------------------------------- </p>
+                {% endif %}
                 {{ relative_containers(object, send_to_jinja) }}
+                {% if rawEleAfter %}
+                    <p style="text-align: center;"> ---------------------------------------------------------------------- </p>
+                {% endif %}
             {% endfor %}
+    
     {% endif %}
+
 {%- endmacro %}

--- a/print_designer/print_designer/page/print_designer/jinja/macros/render.html
+++ b/print_designer/print_designer/page/print_designer/jinja/macros/render.html
@@ -2,17 +2,8 @@
 
 {% macro render(elements, send_to_jinja, rawEleBefore, rawEleAfter) -%}
     {% if element is iterable and (element is not string and element is not mapping) %}
-    
             {% for object in elements %}
-                {% if rawEleBefore %}
-                    <p style="text-align: center;"> ---------------------------------------------------------------------- </p>
-                {% endif %}
-                {{ relative_containers(object, send_to_jinja) }}
-                {% if rawEleAfter %}
-                    <p style="text-align: center;"> ---------------------------------------------------------------------- </p>
-                {% endif %}
+                {{ relative_containers(object, send_to_jinja) }} 
             {% endfor %}
-    
     {% endif %}
-
 {%- endmacro %}

--- a/print_designer/print_designer/page/print_designer/jinja/print_format.html
+++ b/print_designer/print_designer/page/print_designer/jinja/print_format.html
@@ -1,27 +1,3 @@
+
 {% from 'print_designer/page/print_designer/jinja/macros/render.html' import render with context %}
-{% from 'print_designer/page/print_designer/jinja/macros/render_google_fonts.html' import render_google_fonts with context %}
-{% from 'print_designer/page/print_designer/jinja/macros/styles.html' import render_styles with context %}
-
-{{ render_google_fonts(settings) }}
-
-<!-- Don't remove this. user_generated_jinja_code tag is used as placeholder which we replace with user provided jinja template  -->
-<!-- user_generated_jinja_code -->
-<!-- end of user generated code -->
-
-<div id="__print_designer">
-    <div id="header-html">
-        <div style="position: relative; top:0px; left: 0px; width: 100%; height:{{ settings.page.headerHeightWithMargin }}px;">
-            <div class="visible-pdf" style="height: {{ settings.page.marginTop }}px;"></div>
-            <div class="hidden-pdf printview-header-margin" style="height: {{ settings.page.marginTop }}px;"></div>
-            {% if headerElement %}{{ render(pd_format.header, send_to_jinja) }}{%endif%}
-        </div>
-    </div>
-    {% if bodyElement %}{{ render(pd_format.body, send_to_jinja) }}{%endif%}
-    <div id="footer-html">
-        <div style="width: 100%; position: relative; top:0px; left: 0px; height:{{ settings.page.footerHeightWithMargin }}px;">
-            {% if footerElement %}{{ render(pd_format.footer, send_to_jinja) }}{%endif%}
-        </div>
-    </div>
-</div>
-
-{{ render_styles(settings) }}
+    {{ render(element, send_to_jinja) }} 

--- a/print_designer/print_designer/page/print_designer/jinja/print_format.html
+++ b/print_designer/print_designer/page/print_designer/jinja/print_format.html
@@ -1,3 +1,27 @@
-
 {% from 'print_designer/page/print_designer/jinja/macros/render.html' import render with context %}
-    {{ render(element, send_to_jinja) }} 
+{% from 'print_designer/page/print_designer/jinja/macros/render_google_fonts.html' import render_google_fonts with context %}
+{% from 'print_designer/page/print_designer/jinja/macros/styles.html' import render_styles with context %}
+
+{{ render_google_fonts(settings) }}
+
+<!-- Don't remove this. user_generated_jinja_code tag is used as placeholder which we replace with user provided jinja template  -->
+<!-- user_generated_jinja_code -->
+<!-- end of user generated code -->
+
+<div id="__print_designer">
+    <div id="header-html">
+        <div style="position: relative; top:0px; left: 0px; width: 100%; height:{{ settings.page.headerHeightWithMargin }}px;">
+            <div class="visible-pdf" style="height: {{ settings.page.marginTop }}px;"></div>
+            <div class="hidden-pdf printview-header-margin" style="height: {{ settings.page.marginTop }}px;"></div>
+            {% if headerElement %}{{ render(pd_format.header, send_to_jinja) }}{%endif%}
+        </div>
+    </div>
+    {% if bodyElement %}{{ render(pd_format.body, send_to_jinja) }}{%endif%}
+    <div id="footer-html">
+        <div style="width: 100%; position: relative; top:0px; left: 0px; height:{{ settings.page.footerHeightWithMargin }}px;">
+            {% if footerElement %}{{ render(pd_format.footer, send_to_jinja) }}{%endif%}
+        </div>
+    </div>
+</div>
+
+{{ render_styles(settings) }}

--- a/print_designer/print_designer/page/print_designer/jinja/render_header.html
+++ b/print_designer/print_designer/page/print_designer/jinja/render_header.html
@@ -1,0 +1,28 @@
+{% from 'print_designer/page/print_designer/jinja/macros/render.html' import render with context %}
+{% from 'print_designer/page/print_designer/jinja/macros/render_google_fonts.html' import render_google_fonts with context %}
+{% from 'print_designer/page/print_designer/jinja/macros/styles.html' import render_styles with context %}
+
+{{ render_google_fonts(settings) }}
+
+<!-- Don't remove this. user_generated_jinja_code tag is used as placeholder which we replace with user provided jinja template  -->
+<!-- user_generated_jinja_code -->
+<!-- end of user generated code -->
+
+<div id="__print_designer">
+    <div id="header-html">
+        <div style="position: relative; top:0px; left: 0px; width: 100%; height:{{ settings.page.headerHeightWithMargin }}px;">
+            <div class="visible-pdf" style="height: {{ settings.page.marginTop }}px;"></div>
+            <div class="hidden-pdf printview-header-margin" style="height: {{ settings.page.marginTop }}px;"></div>
+            {% if headerElement %}{{ render(pd_format.header, send_to_jinja, rawBeforeElement, rawAfterElement) }}{%endif%}
+        </div>
+    </div>
+
+    {% if bodyElement %}{{ render(pd_format.body, send_to_jinja, rawBeforeElement, rawAfterElement) }}{%endif%}
+    <div id="footer-html">
+        <div style="width: 100%; position: relative; top:0px; left: 0px; height:{{ settings.page.footerHeightWithMargin }}px;">
+            {% if footerElement %}{{ render(pd_format.footer, send_to_jinja, rawBeforeElement, rawAfterElement) }}{%endif%}
+        </div>
+    </div>
+</div>
+
+{{ render_styles(settings) }}

--- a/print_designer/print_designer/page/print_designer/jinja/render_header.html
+++ b/print_designer/print_designer/page/print_designer/jinja/render_header.html
@@ -1,28 +1,5 @@
+
 {% from 'print_designer/page/print_designer/jinja/macros/render.html' import render with context %}
-{% from 'print_designer/page/print_designer/jinja/macros/render_google_fonts.html' import render_google_fonts with context %}
 {% from 'print_designer/page/print_designer/jinja/macros/styles.html' import render_styles with context %}
-
-{{ render_google_fonts(settings) }}
-
-<!-- Don't remove this. user_generated_jinja_code tag is used as placeholder which we replace with user provided jinja template  -->
-<!-- user_generated_jinja_code -->
-<!-- end of user generated code -->
-
-<div id="__print_designer">
-    <div id="header-html">
-        <div style="position: relative; top:0px; left: 0px; width: 100%; height:{{ settings.page.headerHeightWithMargin }}px;">
-            <div class="visible-pdf" style="height: {{ settings.page.marginTop }}px;"></div>
-            <div class="hidden-pdf printview-header-margin" style="height: {{ settings.page.marginTop }}px;"></div>
-            {% if headerElement %}{{ render(pd_format.header, send_to_jinja, rawBeforeElement, rawAfterElement) }}{%endif%}
-        </div>
-    </div>
-
-    {% if bodyElement %}{{ render(pd_format.body, send_to_jinja, rawBeforeElement, rawAfterElement) }}{%endif%}
-    <div id="footer-html">
-        <div style="width: 100%; position: relative; top:0px; left: 0px; height:{{ settings.page.footerHeightWithMargin }}px;">
-            {% if footerElement %}{{ render(pd_format.footer, send_to_jinja, rawBeforeElement, rawAfterElement) }}{%endif%}
-        </div>
-    </div>
-</div>
-
-{{ render_styles(settings) }}
+    {{ render(element, send_to_jinja, "", "") }} 
+    {{ render_styles(settings) }}

--- a/print_designer/print_designer/page/print_designer/jinja/render_header.html
+++ b/print_designer/print_designer/page/print_designer/jinja/render_header.html
@@ -1,5 +1,5 @@
 
 {% from 'print_designer/page/print_designer/jinja/macros/render.html' import render with context %}
 {% from 'print_designer/page/print_designer/jinja/macros/styles.html' import render_styles with context %}
-    {{ render(element, send_to_jinja, "", "") }} 
+    {{ render(element, send_to_jinja) }} 
     {{ render_styles(settings) }}

--- a/print_designer/public/js/print_designer/PropertiesPanelState.js
+++ b/print_designer/public/js/print_designer/PropertiesPanelState.js
@@ -306,6 +306,78 @@ export const createPropertiesPanel = () => {
 		],
 	});
 	MainStore.propertiesPanel.push({
+		title: "Raw Printing",
+		sectionCondtional: () =>
+            true,
+        fields: [
+			{
+				label: "Enable Raw Printing",
+				name: "isRawPrintEnable",
+				isLabelled: true,
+				condtional: () => !MainStore.getCurrentElementsId.length,
+				frappeControl: (ref, name) => {
+					const MainStore = useMainStore();
+					makeFeild({
+						name: name,
+						ref: ref,
+						fieldtype: "Select",
+						requiredData: [MainStore],
+						options: () => [
+							{ label: "Yes", value: true },
+							{ label: "No", value: false },
+						],
+						onChangeCallback: (value = null) => {
+							MainStore.frappeControls[name].$input.blur();
+						},
+						reactiveObject: () => MainStore.page,
+						propertyName: "isRawPrintEnable",
+					});
+				},
+			},
+			{
+				label: "Raw Cmd Before Element",
+				name: "rawCmdBeforeEle",
+				isLabelled: true,
+				condtional: () => MainStore.isRawPrintAllowed && MainStore.getCurrentElementsId.length == 1,
+				frappeControl: (ref, name) => {
+					const MainStore = useMainStore();
+					makeFeild({
+						name: name,
+						ref: ref,
+						fieldtype: "Data",
+						requiredData: [MainStore],
+						
+						onChangeCallback: (value = null) => {
+							MainStore.frappeControls[name].$input.blur();
+						},
+						reactiveObject: () => MainStore.page,
+						propertyName: "rawCmdBeforeEle",
+					});
+				},
+			},
+			{
+				label: "Raw Cmd After Element",
+				name: "rawCmdAfterEle",
+				isLabelled: true,
+				condtional: () => MainStore.isRawPrintAllowed && MainStore.getCurrentElementsId.length == 1,
+				frappeControl: (ref, name) => {
+					const MainStore = useMainStore();
+					makeFeild({
+						name: name,
+						ref: ref,
+						fieldtype: "Data",
+						requiredData: [MainStore],
+						onChangeCallback: (value = null) => {
+							MainStore.frappeControls[name].$input.blur();
+						},
+						reactiveObject: () => MainStore.page,
+						propertyName: "rawCmdAfterEle",
+					});
+				},
+			},
+		],
+	});
+	MainStore.propertiesPanel.push({
 		title: "Page Settings",
 		sectionCondtional: () =>
 			!MainStore.getCurrentElementsId.length && MainStore.activeControl === "mouse-pointer",
@@ -1101,7 +1173,7 @@ export const createPropertiesPanel = () => {
 				}),
 				styleInputwithIcon("lineHeight", 23, {
 					padding: 5,
-					isRaw: true,
+					isRaw: false,
 					isFontStyle: true,
 				}),
 			],

--- a/print_designer/public/js/print_designer/PropertiesPanelState.js
+++ b/print_designer/public/js/print_designer/PropertiesPanelState.js
@@ -346,11 +346,7 @@ export const createPropertiesPanel = () => {
 						ref: ref,
 						fieldtype: "Data",
 						requiredData: [MainStore],
-						
-						onChangeCallback: (value = null) => {
-							MainStore.frappeControls[name].$input.blur();
-						},
-						reactiveObject: () => MainStore.page,
+						reactiveObject: () => MainStore.getCurrentElementsValues[0],
 						propertyName: "rawCmdBeforeEle",
 					});
 				},
@@ -365,12 +361,20 @@ export const createPropertiesPanel = () => {
 					makeFeild({
 						name: name,
 						ref: ref,
-						fieldtype: "Data",
-						requiredData: [MainStore],
+						fieldtype: "Select",
+						requiredData: [MainStore.getCurrentElementsValues[0]],
+						options: () => [
+							{ label: "Paper Cut", value: "paper_cut" },
+							{ label: "No", value: "No" },
+						],
 						onChangeCallback: (value = null) => {
-							MainStore.frappeControls[name].$input.blur();
+							if (value && MainStore.getCurrentElementsValues[0]) {
+								MainStore.getCurrentElementsValues[0]["rawCmdAfterEle"] =
+									value === "Yes";
+								MainStore.frappeControls[name].$input.blur();
+							}
 						},
-						reactiveObject: () => MainStore.page,
+						reactiveObject: () => MainStore.getCurrentElementsValues[0],
 						propertyName: "rawCmdAfterEle",
 					});
 				},
@@ -864,52 +868,7 @@ export const createPropertiesPanel = () => {
 			[colorStyleFrappeControl("Background", "rectangleBackgroundColor", "backgroundColor")],
 		],
 	});
-	MainStore.propertiesPanel.push({
-		title: "Enable Jinja Parsing",
-		sectionCondtional: () =>
-			MainStore.getCurrentElementsId.length === 1 &&
-			MainStore.getCurrentElementsValues[0].type === "text" &&
-			!MainStore.getCurrentElementsValues[0].isDynamic,
-		fields: [
-			[
-				{
-					label: "Render Jinja",
-					name: "parseJinja",
-					labelDirection: "column",
-					condtional: () =>
-						MainStore.getCurrentElementsId.length === 1 &&
-						MainStore.getCurrentElementsValues[0].type === "text" &&
-						!MainStore.getCurrentElementsValues[0].isDynamic,
-					frappeControl: (ref, name) => {
-						const MainStore = useMainStore();
-						makeFeild({
-							name: name,
-							ref: ref,
-							fieldtype: "Select",
-							requiredData: [MainStore.getCurrentElementsValues[0]],
-							options: () => [
-								{ label: "Yes", value: "Yes" },
-								{ label: "No", value: "No" },
-							],
-							formatValue: (object, property, isStyle) => {
-								if (!object) return;
-								return object[property] ? "Yes" : "No";
-							},
-							onChangeCallback: (value = null) => {
-								if (value && MainStore.getCurrentElementsValues[0]) {
-									MainStore.getCurrentElementsValues[0]["parseJinja"] =
-										value === "Yes";
-									MainStore.frappeControls[name].$input.blur();
-								}
-							},
-							reactiveObject: () => MainStore.getCurrentElementsValues[0],
-							propertyName: "parseJinja",
-						});
-					},
-				},
-			],
-		],
-	});
+	
 	MainStore.propertiesPanel.push({
 		title: "Text Tool",
 		sectionCondtional: () => MainStore.activeControl === "text",

--- a/print_designer/public/js/print_designer/PropertiesPanelState.js
+++ b/print_designer/public/js/print_designer/PropertiesPanelState.js
@@ -308,13 +308,13 @@ export const createPropertiesPanel = () => {
 	MainStore.propertiesPanel.push({
 		title: "Raw Printing",
 		sectionCondtional: () =>
-            MainStore.isRawPrintAllowed &&  MainStore.getCurrentElementsId.length == 1,
+            MainStore.isRawPrintAllowed &&  MainStore.getCurrentElementsId.length == 1 && !MainStore.getCurrentElementsValues[0].isElementOverlapping,
         fields: [
 			{
 				label: "Raw Cmd Before Element",
 				name: "rawCmdBeforeEle",
 				isLabelled: true,
-				condtional: () => MainStore.isRawPrintAllowed && MainStore.getCurrentElementsId.length == 1,
+				condtional: () => MainStore.isRawPrintAllowed && MainStore.getCurrentElementsId.length == 1 && !MainStore.getCurrentElementsValues[0].isElementOverlapping,
 				frappeControl: (ref, name) => {
 					const MainStore = useMainStore();
 					makeFeild({
@@ -331,25 +331,14 @@ export const createPropertiesPanel = () => {
 				label: "Raw Cmd After Element",
 				name: "rawCmdAfterEle",
 				isLabelled: true,
-				condtional: () => MainStore.isRawPrintAllowed && MainStore.getCurrentElementsId.length == 1,
+				condtional: () => MainStore.isRawPrintAllowed && MainStore.getCurrentElementsId.length == 1 && !MainStore.getCurrentElementsValues[0].isElementOverlapping,
 				frappeControl: (ref, name) => {
 					const MainStore = useMainStore();
 					makeFeild({
 						name: name,
 						ref: ref,
-						fieldtype: "Select",
+						fieldtype: "Data",
 						requiredData: [MainStore.getCurrentElementsValues[0]],
-						options: () => [
-							{ label: "Paper Cut", value: "paper_cut" },
-							{ label: "No", value: "No" },
-						],
-						onChangeCallback: (value = null) => {
-							if (value && MainStore.getCurrentElementsValues[0]) {
-								MainStore.getCurrentElementsValues[0]["rawCmdAfterEle"] =
-									value === "paper_cut";
-								MainStore.frappeControls[name].$input.blur();
-							}
-						},
 						reactiveObject: () => MainStore.getCurrentElementsValues[0],
 						propertyName: "rawCmdAfterEle",
 					});

--- a/print_designer/public/js/print_designer/PropertiesPanelState.js
+++ b/print_designer/public/js/print_designer/PropertiesPanelState.js
@@ -308,32 +308,8 @@ export const createPropertiesPanel = () => {
 	MainStore.propertiesPanel.push({
 		title: "Raw Printing",
 		sectionCondtional: () =>
-            true,
+            MainStore.isRawPrintAllowed &&  MainStore.getCurrentElementsId.length == 1,
         fields: [
-			{
-				label: "Enable Raw Printing",
-				name: "isRawPrintEnable",
-				isLabelled: true,
-				condtional: () => !MainStore.getCurrentElementsId.length,
-				frappeControl: (ref, name) => {
-					const MainStore = useMainStore();
-					makeFeild({
-						name: name,
-						ref: ref,
-						fieldtype: "Select",
-						requiredData: [MainStore],
-						options: () => [
-							{ label: "Yes", value: true },
-							{ label: "No", value: false },
-						],
-						onChangeCallback: (value = null) => {
-							MainStore.frappeControls[name].$input.blur();
-						},
-						reactiveObject: () => MainStore.page,
-						propertyName: "isRawPrintEnable",
-					});
-				},
-			},
 			{
 				label: "Raw Cmd Before Element",
 				name: "rawCmdBeforeEle",
@@ -370,7 +346,7 @@ export const createPropertiesPanel = () => {
 						onChangeCallback: (value = null) => {
 							if (value && MainStore.getCurrentElementsValues[0]) {
 								MainStore.getCurrentElementsValues[0]["rawCmdAfterEle"] =
-									value === "Yes";
+									value === "paper_cut";
 								MainStore.frappeControls[name].$input.blur();
 							}
 						},

--- a/print_designer/public/js/print_designer/store/MainStore.js
+++ b/print_designer/public/js/print_designer/store/MainStore.js
@@ -192,8 +192,10 @@ export const useMainStore = defineStore("MainStore", {
 			return Object.keys(this.currentElements);
 		},
 		isRawPrintAllowed(){
-			let printSettings = frappe.model.get_doc(":Print Settings", "Print Settings")
-			return (printSettings.enable_raw_printing == '1')? true:false
+			return frappe.db.get_single_value("Print Settings", "enable_raw_printing").then((response)=>{ 
+				 response
+			})
+			 
 		},
 		getLinkMetaFields: (state) => {
 			return (search_string = null, parentField) => {

--- a/print_designer/public/js/print_designer/store/MainStore.js
+++ b/print_designer/public/js/print_designer/store/MainStore.js
@@ -146,6 +146,7 @@ export const useMainStore = defineStore("MainStore", {
 				id: "barcode",
 				cursor: "url('/assets/print_designer/images/add-barcode.svg') 6 6, crosshair",
 			},
+		
 		},
 		propertiesPanel: [],
 	}),
@@ -189,6 +190,10 @@ export const useMainStore = defineStore("MainStore", {
 		},
 		getCurrentElementsId() {
 			return Object.keys(this.currentElements);
+		},
+		isRawPrintAllowed(){
+			let printSettings = frappe.model.get_doc(":Print Settings", "Print Settings")
+			return (printSettings.enable_raw_printing == '1')? true:false
 		},
 		getLinkMetaFields: (state) => {
 			return (search_string = null, parentField) => {

--- a/print_designer/public/js/print_designer/store/MainStore.js
+++ b/print_designer/public/js/print_designer/store/MainStore.js
@@ -192,10 +192,8 @@ export const useMainStore = defineStore("MainStore", {
 			return Object.keys(this.currentElements);
 		},
 		isRawPrintAllowed(){
-			return frappe.db.get_single_value("Print Settings", "enable_raw_printing").then((response)=>{ 
-				 response
-			})
-			 
+			let printSettings = frappe.model.get_doc(":Print Settings", "Print Settings")
+			return (printSettings.enable_raw_cmd_print_designer == '1')? true:false
 		},
 		getLinkMetaFields: (state) => {
 			return (search_string = null, parentField) => {


### PR DESCRIPTION
1. Create a method to render each element
2. Overwrite get_print_html() to enable print preview for 'raw print'

Issue :
1. Trying to more options value for select fieldtype in `print designer` screen is going in loop, no logs in console.
![Screenshot 2024-05-21 at 12 17 32 PM](https://github.com/frappe/print_designer/assets/167201419/ebc638ec-542b-40bd-83dd-fa71f11f7830)


2. Need to fetch `print settings` single value, when used get_single_value() due to callback facing some issue.


Progress :

1. Validation for overlapping, eg : If in same row if two rectangle is drawn then on save button it will throw error
![Screenshot 2024-05-21 at 11 35 06 AM](https://github.com/frappe/print_designer/assets/167201419/73873fd9-eacd-4e62-ade7-f31768896423)


2. Need to fetch `print settings` single value, when used get_single_value() due to callback facing some issue.


What Next :
1. If child element is selected then 'Raw Cmd before/after'  will not visible.

