### PR TITLE
fix: patch old formats for multi page

### DIFF
--- a/print_designer/patches.txt
+++ b/print_designer/patches.txt
@@ -16,3 +16,4 @@ print_designer.patches.remove_unused_rectangle_gs_properties
 print_designer.patches.change_dynamic_height_variable
 print_designer.patches.introduce_z_index
 print_designer.patches.move_header_footers_to_new_schema
+print_designer.patches.convert_formats_for_recursive_container

--- a/print_designer/patches/convert_formats_for_recursive_container.py
+++ b/print_designer/patches/convert_formats_for_recursive_container.py
@@ -1,0 +1,60 @@
+import frappe
+
+from print_designer.pdf import is_older_schema
+
+
+def patch_format():
+	print_formats = frappe.get_all(
+		"Print Format",
+		filters={"print_designer": 1},
+		fields=[
+			"name",
+			"print_designer_print_format",
+			"print_designer_settings",
+		],
+	)
+	for pf in print_formats:
+		settings = frappe.json.loads(pf.print_designer_settings or "{}")
+		if not is_older_schema(settings=settings, current_version="1.1.0") and is_older_schema(
+			settings=settings, current_version="1.3.0"
+		):
+			pf_print_format = frappe.json.loads(pf.print_designer_print_format)
+
+			for headerType in ["firstPage", "oddPage", "evenPage", "lastPage"]:
+				for row in pf_print_format["header"][headerType]:
+					row["layoutType"] = "row"
+					for column in row["childrens"]:
+						column["layoutType"] = "column"
+
+			for footerType in ["firstPage", "oddPage", "evenPage", "lastPage"]:
+				for row in pf_print_format["footer"][footerType]:
+					row["layoutType"] = "row"
+					for column in row["childrens"]:
+						column["layoutType"] = "column"
+
+			for row in pf_print_format["body"]:
+				row["layoutType"] = "row"
+				for column in row["childrens"]:
+					column["layoutType"] = "column"
+			# body elements should be inside page object forgot to add it in patch move_header_footers_to_new_schema
+			pf_print_format["body"] = [
+				{
+					"index": 0,
+					"type": "page",
+					"childrens": pf_print_format["body"],
+					"isDropZone": True,
+				}
+			]
+
+			frappe.set_value(
+				"Print Format",
+				pf.name,
+				{"print_designer_print_format": frappe.json.dumps(pf_print_format)},
+			)
+
+	return print_formats
+
+
+def execute():
+	"""add layoutType to rows and columns in old print formats."""
+	patch_format()

--- a/print_designer/patches/move_header_footers_to_new_schema.py
+++ b/print_designer/patches/move_header_footers_to_new_schema.py
@@ -92,5 +92,5 @@ def patch_format():
 
 
 def execute():
-	"""Updating Table and Dynamic Text Elements to have property isDynamicHeight with default value as True"""
+	"""Moved header and footer to new schema."""
 	patch_format()


### PR DESCRIPTION
forgot to patch body elements to be inside page object which caused breakage in formats.

also updated layoutType property in row and column object.

chore: updated correct description for the patch