### PR TITLE
feat: allow signature in dynamic text

### DIFF
--- a/print_designer/print_designer/page/print_designer/jinja/macros/spantag.html
+++ b/print_designer/print_designer/page/print_designer/jinja/macros/spantag.html
@@ -15,13 +15,25 @@
         {%- set value = _(frappe.db.get_value(field.doctype, doc[field.parentField], field.fieldname)) -%}
         {{ frappe.format(value, {'fieldtype': field.fieldtype, 'options': field.options}) }}
     {%- elif row -%}
-    {%- if field.fieldtype == "Image" and row.get(field['options']) -%}
-        <img class="print-item-image" src="{{ row.get(field['options']) }}" alt="">
+        {%- if field.fieldtype == "Image" and row.get(field['options']) -%}
+            <img class="print-item-image" src="{{ row.get(field['options']) }}" alt="">
+        {%- elif field.fieldtype == "Signature" -%}
+            {%- if doc.get_formatted(field.fieldname) != "/assets/frappe/images/signature-placeholder.png" -%}
+                <img class="print-item-image" src="{{doc.get_formatted(field.fieldname)}}" alt="">
+            {%- endif -%}
+        {%- else -%}
+            {{row.get_formatted(field.fieldname)}}
+        {%- endif -%}
     {%- else -%}
-        {{row.get_formatted(field.fieldname)}}
-    {%- endif -%}
-    {%- else -%}
-        {{doc.get_formatted(field.fieldname)}}
+        {%- if field.fieldtype == "Image" and doc.get(field['options']) -%}
+            <img class="print-item-image" src="{{ doc.get(field['options']) }}" alt="">
+        {%- elif field.fieldtype == "Signature" -%}
+            {%- if doc.get_formatted(field.fieldname) != "/assets/frappe/images/signature-placeholder.png" -%}
+                <img class="print-item-image" src="{{doc.get_formatted(field.fieldname)}}" alt="">
+            {%- endif -%}
+        {%- else -%}
+            {{doc.get_formatted(field.fieldname)}}
+        {%- endif -%}
     {%- endif -%}
 {%- endmacro -%}
 

--- a/print_designer/public/js/print_designer/utils.js
+++ b/print_designer/public/js/print_designer/utils.js
@@ -443,7 +443,7 @@ export const getFormattedValue = async (field, row = null) => {
 			MainStore.docData
 		);
 		if (!formattedValue.value) {
-			if (["Image, Attach Image"].indexOf(field.fieldtype) != -1) {
+			if (["Image", "Attach Image"].indexOf(field.fieldtype) != -1) {
 				formattedValue.value = null;
 			} else {
 				switch (field.fieldname) {
@@ -466,6 +466,9 @@ export const getFormattedValue = async (field, row = null) => {
 				}
 			}
 		}
+	}
+	if (field.fieldtype == "Signature") {
+		formattedValue.value = `<img class="print-item-image" src="${formattedValue.value}" alt="">`;
 	}
 	return formattedValue.value;
 };


### PR DESCRIPTION
signature field is saved as base64 encoded string in the database. i just added img tag and set the src attribute to the base64 encoded string.


https://github.com/frappe/print_designer/assets/39730881/96137271-bbb1-4556-890d-c981aa69b074

fixes #110 #276 
