### PR TITLE
refactor(minor): call whitelisted method to get meta

### DIFF
--- a/print_designer/print_designer/page/print_designer/print_designer.py
+++ b/print_designer/print_designer/page/print_designer/print_designer.py
@@ -20,6 +20,11 @@ def render_user_text_withdoc(string, doctype, docname=None, row=None, send_to_ji
 
 
 @frappe.whitelist(allow_guest=False)
+def get_meta(doctype):
+	return frappe.get_meta(doctype).as_dict()
+
+
+@frappe.whitelist(allow_guest=False)
 def render_user_text(string, doc, row=None, send_to_jinja=None):
 	if not row:
 		row = {}

--- a/print_designer/public/js/print_designer/components/layout/AppDynamicTextModal.vue
+++ b/print_designer/public/js/print_designer/components/layout/AppDynamicTextModal.vue
@@ -277,41 +277,11 @@ const selectField = async (field, fieldtype) => {
 	});
 	if (isRemoved) return;
 	let index = fieldnames.value.length;
-	let rowValue = null;
-	if (props.table) {
-		rowValue = MainStore.docData[props.table.fieldname][0];
-	}
-	let value = await getFormattedValue(field, rowValue);
-	if (!value) {
-		if (["Image, Attach Image"].indexOf(field.fieldtype) != -1) {
-			value = null;
-		} else {
-			switch (field.fieldname) {
-				case "page":
-					value = "0";
-					break;
-				case "topage":
-					value = "999";
-					break;
-				case "date":
-					value = frappe.datetime.now_date();
-					break;
-				case "time":
-					value = frappe.datetime.now_time();
-					break;
-				default:
-					value = `{{ ${
-						previewRef.value.parentField ? previewRef.value.parentField + "." : ""
-					}${field.fieldname} }}`;
-			}
-		}
-	}
 	let dynamicField = {
 		doctype: doctype.value,
 		parentField: previewRef.value.parentField,
 		fieldname: field.fieldname,
 		options: field.options,
-		value,
 		fieldtype,
 		label: props.table ? field.label : `${field.label} :`,
 		suffix: null,
@@ -323,6 +293,11 @@ const selectField = async (field, fieldtype) => {
 		labelStyle: {},
 		nextLine: !props.table,
 	};
+	let rowValue = null;
+	if (props.table) {
+		rowValue = MainStore.docData[props.table.fieldname][0];
+	}
+	dynamicField["value"] = await getFormattedValue(dynamicField, rowValue);
 	if (previewRef.value.selectedEl) {
 		index = previewRef.value.selectedEl.index + 1;
 		fieldnames.value.splice(index, 0, dynamicField);


### PR DESCRIPTION
using with_doctype stores meta in localstorage which causes it to be full and is not required to replaced it with get_meta method in print designer