### PR TITLE
feat: the user can now change the background color of the whole document

### DIFF
--- a/print_designer/public/js/print_designer/PropertiesPanelState.js
+++ b/print_designer/public/js/print_designer/PropertiesPanelState.js
@@ -1,13 +1,13 @@
-import { storeToRefs } from "pinia";
-import { makeFeild } from "./frappeControl";
-import { useElementStore } from "./store/ElementStore";
 import { useMainStore } from "./store/MainStore";
+import { useElementStore } from "./store/ElementStore";
+import { makeFeild } from "./frappeControl";
+import { storeToRefs } from "pinia";
 import {
-    getConditonalObject,
-    getParentPage,
-    handleAlignIconClick,
-    handleBorderIconClick,
-    parseFloatAndUnit,
+	parseFloatAndUnit,
+	handleAlignIconClick,
+	handleBorderIconClick,
+	getConditonalObject,
+	getParentPage,
 } from "./utils";
 export const createPropertiesPanel = () => {
 	const MainStore = useMainStore();

--- a/print_designer/public/js/print_designer/components/layout/AppCanvas.vue
+++ b/print_designer/public/js/print_designer/components/layout/AppCanvas.vue
@@ -353,10 +353,6 @@ onMounted(() => {
 						MainStore.convertToPageUOM(MainStore.page.marginRight) +
 							MainStore.page.UOM,
 					],
-					[
-						"--print-page-bg",
-						MainStore.page.backgroundColor,
-					],
 				],
 			]);
 		}

--- a/print_designer/public/js/print_designer/components/layout/AppPages.vue
+++ b/print_designer/public/js/print_designer/components/layout/AppPages.vue
@@ -434,7 +434,7 @@ const ElementStore = useElementStore();
 
 	& .main-container {
 		position: relative;
-		background-color: var(--print-background-color);
+		background-color: white;
 		height: 100%;
 		margin-left: calc(-1 * var(--print-margin-left));
 		scroll-margin-top: 50px;


### PR DESCRIPTION
This feature comes to allow user to change the background color, see the video below.


https://github.com/frappe/print_designer/assets/75337003/30c947fc-b53d-444c-bbfd-00c7d25b9b89


- The filler is mandatory because the `div` do not ends at the end of the document, but at the end of the user input
- This also comes with little tricks with margins, obtained during testing. For example, if you remove the margin trick in styles.html, then you'll have a white 1px margin to the right of the document, leaving your print format unusable before cropping.

Please feel free to blame me if there's something wrong with the code.