### PR TITLE
feat: user can now change the background of the whole document

### DIFF
--- a/print_designer/print_designer/page/print_designer/jinja/macros/styles.html
+++ b/print_designer/print_designer/page/print_designer/jinja/macros/styles.html
@@ -1,16 +1,28 @@
 {% macro render_styles(settings) %}
 <style>
+	#filler{
+        background-color: {{ settings.page.backgroundColor}};
+        margin-top: -10px; /* Come back to avoid strange gray line between the content and filler */
+        height: 10000%; /* Fill the entire page even for huge formats */
+        position: fixed;
+        width: 10000%; /* Fill the entire page even for huge formats */
+        z-index: 0;
+    }
     .print-format {
         box-sizing: border-box;
         padding: 0in;
         max-width: {{convert_uom(number=settings.page.width, to_uom="mm")}} !important;
         dpi: {{settings.PDFPrintDPI or 96}}mm;
         page-width: {{convert_uom(number=settings.page.width, to_uom="mm")}};
+        /* 5mm margin to avoid strange blank */
+        /* vertical line to the right */
+        page-width: {{convert_uom(number=settings.page.width - ((settings.page.width % 2 + 1) * 2), to_uom="mm")}};
         page-height: {{convert_uom(number=settings.page.height, to_uom="mm")}};
         margin-top:{{convert_uom(number=settings.page.headerHeightWithMargin or settings.page.marginTop, to_uom='mm')}};
         margin-bottom:{{convert_uom(number=settings.page.footerHeightWithMargin or settings.page.marginBottom, to_uom='mm')}};
         margin-left:{{convert_uom(number=settings.page.marginLeft, to_uom='mm')}};
         margin-right:{{convert_uom(number=settings.page.marginRight, to_uom='mm')}};
+        background-color: {{ settings.page.backgroundColor}};
     }
     @media screen {
         #__print_designer {

--- a/print_designer/print_designer/page/print_designer/jinja/print_format.html
+++ b/print_designer/print_designer/page/print_designer/jinja/print_format.html
@@ -33,5 +33,6 @@
         </div>
     </div>
 </div>
+<div id="filler"/>
 
 {{ render_styles(settings) }}

--- a/print_designer/public/js/print_designer/PropertiesPanelState.js
+++ b/print_designer/public/js/print_designer/PropertiesPanelState.js
@@ -389,6 +389,23 @@ export const createPropertiesPanel = () => {
 					});
 				},
 			},
+                {
+                    label: "Background",
+                    name: "pageBackground",
+                    isLabelled: true,
+                    condtional: null,
+                    frappeControl: (ref, name) => {
+                        const { page } = storeToRefs(MainStore);
+                        makeFeild({
+                            name,
+                            ref,
+                            fieldtype: "Color",
+                            requiredData: () => page.backgroundColor,
+                            reactiveObject: page,
+                            propertyName: "backgroundColor",
+                        });
+                    },
+                },
 			[
 				pageInput("Height", "page_height", "height", {
 					parentBorderTop: true,

--- a/print_designer/public/js/print_designer/store/MainStore.js
+++ b/print_designer/public/js/print_designer/store/MainStore.js
@@ -91,6 +91,7 @@ export const useMainStore = defineStore("MainStore", {
 			headerHeightWithMargin: 0,
 			footerHeightWithMargin: 0,
 			UOM: "mm",
+            backgroundColor: "#ffffff",
 		},
 		controls: {
 			MousePointer: {
@@ -185,6 +186,7 @@ export const useMainStore = defineStore("MainStore", {
 		},
 		getPageSettings() {
 			return {
+                backgroundColor: this.page.backgroundColor,
 				height:
 					this.convertToPageUOM(
 						this.page.height - (this.page.marginTop + this.page.marginBottom)


### PR DESCRIPTION
This feature comes to allow user to change the background color, see the video below.


https://github.com/frappe/print_designer/assets/75337003/39745bc9-c402-4b2b-8a2e-815bf2291658


- The filler is mandatory because the `div` do not ends at the end of the document, but at the end of the user input
- This also comes with little tricks with margins, obtained during testing. For example, if you remove the margin trick in `styles.html`, then you'll have a white 1px margin to the right of the document, leaving your print format unusable before cropping.

Please feel free to blame me if there's something wrong with the code.