### PR TITLE
fix: update key bindings logic as per new Structure

### DIFF
--- a/print_designer/public/js/print_designer/composables/AttachKeyBindings.js
+++ b/print_designer/public/js/print_designer/composables/AttachKeyBindings.js
@@ -45,7 +45,7 @@ export function useAttachKeyBindings() {
 	const handleKeyDown = async (e) => {
 		MainStore.isAltKey = e.altKey;
 		MainStore.isShiftKey = e.shiftKey;
-		if (e.target !== document.body || MainStore.openModal) return;
+		if (!e.target.classList.contains("print-format-container") || MainStore.openModal) return;
 		if (e.ctrlKey || e.metaKey) {
 			if (["a", "A"].indexOf(e.key) != -1) {
 				ElementStore.Elements.forEach((page) => {


### PR DESCRIPTION
After Multi page refactor, key bindings logic was not working as expected. There was a check which would return if target was not document.body but that was incorrect as we changed Structure of canvas area.