### PR TITLE
fix: Null Canvas Container Issue in Print Designer

### DIFF
--- a/print_designer/print_designer/client_scripts/print.js
+++ b/print_designer/print_designer/client_scripts/print.js
@@ -121,6 +121,12 @@ frappe.ui.form.PrintView = class PrintView extends frappe.ui.form.PrintView {
 		let page_settings = print_designer_settings.page;
 		let canvasContainer = document.getElementById("preview-container");
 		const wrapperContainer = document.getElementsByClassName("print-designer-wrapper")[0];
+		if (!canvasContainer) {
+			$(wrapperContainer).empty();
+			canvasContainer = document.createElement("div");
+			canvasContainer.id = "preview-container";
+			wrapperContainer.appendChild(canvasContainer);
+		}
 		canvasContainer.style.minHeight = page_settings.height + "px";
 		canvasContainer.style.width = page_settings.width + "px";
 		canvasContainer.innerHTML = `${frappe.render_template("print_skeleton_loading")}`;


### PR DESCRIPTION
When the print preview is loaded for the second time, the canvas container (with the ID "preview-container") returns null because it was removed from the DOM during the initial load. This causes a TypeError when the code tries to access its style properties. The solution is to check if the canvas container exists, and if not, empty the wrapper container and create a new canvas container before appending it. The code used to implement this solution is as follows:
```
if (!canvasContainer) {
	$(wrapperContainer).empty();
	canvasContainer = document.createElement("div");
	canvasContainer.id = "preview-container";
	wrapperContainer.appendChild(canvasContainer);
}

```
