### PR TITLE
fix: added menu option to download pdf

### DIFF
--- a/print_designer/print_designer/client_scripts/print.js
+++ b/print_designer/print_designer/client_scripts/print.js
@@ -195,6 +195,7 @@ frappe.ui.form.PrintView = class PrintView extends frappe.ui.form.PrintView {
 			this.designer_pdf(print_format);
 			this.full_page_btn.hide();
 			this.pdf_btn.hide();
+			this.page.add_menu_item("Download PDF", () => this.render_pdf());
 			this.print_btn.hide();
 			this.letterhead_selector.hide();
 			this.sidebar_dynamic_section.hide();


### PR DESCRIPTION
i recently removed pdfjs from source code as it was used for better ux. however, as it was dependancy nighmare i removed it in favour of browser's  built in pdf viewer.

i also removed download_pdf button as pdf viewer has download icon (atleasr Chrome/Mozilla).

i recently found that some browser's default pdf viewer doesn't have download button so added one in menu.