### PR TITLE
fix: change print_designer chromium location

### DIFF
--- a/print_designer/install.py
+++ b/print_designer/install.py
@@ -104,7 +104,7 @@ def find_or_download_chromium_executable():
 def download_chromium():
 	bench_path = frappe.utils.get_bench_path()
 	"""Download and extract Chromium for the specific version at the bench level."""
-	chromium_dir = os.path.join(bench_path, "chromium")
+	chromium_dir = os.path.join(bench_path, "sites", "print_designer_chromium")
 
 	# Remove old Chromium directory if it exists
 	if os.path.exists(chromium_dir):

--- a/print_designer/pdf_generator/generator.py
+++ b/print_designer/pdf_generator/generator.py
@@ -87,7 +87,7 @@ class FrappePDFGenerator:
 		"""Finds the Chromium executable or raises an error if not found."""
 		bench_path = frappe.utils.get_bench_path()
 		"""Determine the path to the Chromium executable. chromium is downloaded by download_chromium in print_designer/install.py"""
-		chromium_dir = os.path.join(bench_path, "chromium")
+		chromium_dir = os.path.join(bench_path, "sites", "print_designer_chromium")
 
 		if not os.path.exists(chromium_dir):
 			frappe.throw("Chromium is not downloaded. Please run the setup first.")


### PR DESCRIPTION
Change chromium executable location to `/frappe-bench/sites/print_designer_chromium` in order to ensure global access to this executable in multi-container environments.

fixes #432 
fixes #437 