### PR TITLE
Fix image rendering

### DIFF
--- a/print_designer/print_designer/page/print_designer/jinja/macros/image.html
+++ b/print_designer/print_designer/page/print_designer/jinja/macros/image.html
@@ -18,7 +18,7 @@
     class="image {{ element.classes | join(' ') }}"
 >
     <div
-        style="width:100%; height:100%; background-image: url('{{frappe.get_url()}}{{value}}');"
+        style="width:100%; height:100%; background-image: url('{{value}}');"
         class="image {{ element.classes | join(' ') }}"
     ></div>
 </div>


### PR DESCRIPTION
With Frappe version 15.67.0, images are not rendered correctly when using a newly created Print Format. This is because frappe.get_url() is already included in the value variable, leading to broken URLs. It's unclear when this behavior was changed in Frappe.

Note: This issue only affects newly created Print Formats.

Additionally, the case where a file has a file_url seems problematic. It likely never worked as expected, since appending frappe.get_url() results in invalid URLs (e.g., www.myFrappe.testwww.imagesource.test/img.png). In such cases, appending the base URL was probably always unnecessary.