### PR TITLE
Fix: don't download chromium if it is configured and installed

### DIFF
--- a/print_designer/pdf_generator/cdp_connection.py
+++ b/print_designer/pdf_generator/cdp_connection.py
@@ -92,7 +92,7 @@ class CDPSocketClient:
 
 	async def _disconnect(self):
 		try:
-			if self.connection and not self.connection.close:
+			if self.connection and not self.connection.closed:
 				await self.connection.close()
 			self.connection = None
 		except Exception as e:


### PR DESCRIPTION
Don't download chromium if it's chromium_binary_path is configured in common_site_config.json and present. If it is not configured, or if it is configured but not present at the configured path, continue with the logic of checking in the bench directory.