### PR TITLE
fix: there is no attribute for closed, just handle the exception as the docs suggest

### DIFF
--- a/print_designer/pdf_generator/cdp_connection.py
+++ b/print_designer/pdf_generator/cdp_connection.py
@@ -92,10 +92,10 @@ class CDPSocketClient:
 
 	async def _disconnect(self):
 		try:
-			if self.connection and not self.connection.closed:
+			if self.connection:
 				await self.connection.close()
 			self.connection = None
-		except Exception as e:
+		except Exception:
 			frappe.log_error(
 				title="Error during WebSocket disconnection:", message=f"{frappe.get_traceback()}"
 			)


### PR DESCRIPTION
Closes #455 

ref: https://websockets.readthedocs.io/en/stable/reference/asyncio/client.html#websockets.asyncio.client.ClientConnection
