### PR TITLE
fix: handle case when pdf_generator field not present

### DIFF
--- a/print_designer/install.py
+++ b/print_designer/install.py
@@ -323,7 +323,12 @@ def add_pdf_generator_option():
 
 
 def set_pdf_generator_option(action: Literal["add", "remove"]):
-	options = (frappe.get_meta("Print Format").get_field("pdf_generator").options).split("\n")
+	field = frappe.get_meta("Print Format").get_field("pdf_generator")
+
+	if not field:
+		return
+
+	options = (field.options).split("\n")
 
 	if "chrome" in options and action == "add":
 		return


### PR DESCRIPTION
* Case when Framework is not updated, but print designer is installed


> Better fix is to add requirement for a specific Framework version whenever we depend on a newly merged feature
