### PR TITLE
fix(commands): init site context before setup-chrome and fix chrome typo

### DIFF
--- a/print_designer/commands/__init__.py
+++ b/print_designer/commands/__init__.py
@@ -1,11 +1,26 @@
 import click
+import frappe
+from frappe.commands import pass_context
+from frappe.exceptions import SiteNotSpecifiedError
+from frappe.utils.bench_helper import CliCtxObj
 
 
 @click.command("setup-chrome", help="setup chrome (server-side) for pdf generation")
-def setup_chorme():
+@pass_context
+def setup_chrome(context: CliCtxObj):
 	from print_designer.install import setup_chromium
 
-	setup_chromium()
+	if not context.sites:
+		raise SiteNotSpecifiedError
+
+	for site in context.sites:
+		try:
+			frappe.init(site)
+			frappe.connect()
+			setup_chromium()
+			frappe.db.commit()
+		finally:
+			frappe.destroy()
 
 
-commands = [setup_chorme]
+commands = [setup_chrome]


### PR DESCRIPTION
- Initialize site context for each target site before running setup-chrome
- Commit and clean up connections after running setup
- Fix typo in command handler name (`setup_chorme` → `setup_chrome`)

Resolves: Error occurs when using the `bench setup-chorme`  command.
```bash
frappe@906c010f52ca:~/frappe-bench$ bench --site site1.local setup-chro
me
Chromium is already set up at /home/frappe/frappe-bench/chromium/chrome-linux/headless_shell
Traceback (most recent call last):
File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 48, in invoke
return super().invoke(ctx)
~~~~~~~~~~~~~~^^^^^
File "/home/frappe/frappe-bench/env/lib/python3.14/site-packages/click/core.py", line 1873, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
File "/home/frappe/frappe-bench/env/lib/python3.14/site-packages/click/core.py", line 1269, in invoke
return ctx.invoke(self.callback, **ctx.params)
~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/frappe/frappe-bench/env/lib/python3.14/site-packages/click/core.py", line 824, in invoke
return callback(*args, **kwargs)
File "/home/frappe/frappe-bench/apps/print_designer/print_designer/commands/__init__.py", line 8, in setup_chorme
setup_chromium()
~~~~~~~~~~~~~~^^
File "/usr/lib/python3.14/contextlib.py", line 85, in inner
return func(*args, **kwds)
File "/home/frappe/frappe-bench/apps/print_designer/print_designer/install.py", line 62, in setup_chromium
add_pdf_generator_option()
~~~~~~~~~~~~~~~~~~~~~~~~^^
File "/home/frappe/frappe-bench/apps/print_designer/print_designer/install.py", line 322, in add_pdf_generator_option
set_pdf_generator_option("add")
~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^
File "/home/frappe/frappe-bench/apps/print_designer/print_designer/install.py", line 326, in set_pdf_generator_option
field = frappe.get_meta("Print Format").get_field("pdf_generator")
~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
File "/home/frappe/frappe-bench/apps/frappe/frappe/model/meta.py", line 85, in get_meta
and (meta := frappe.client_cache.get_value(f"doctype_meta::{doctype}"))
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get_value'

'NoneType' object has no attribute 'get_value'
```