### PR TITLE
feat: align chromium path keys with Frappe Core

### DIFF
--- a/print_designer/pdf_generator/generator.py
+++ b/print_designer/pdf_generator/generator.py
@@ -63,7 +63,7 @@ class FrappePDFGenerator:
 			return
 
 		# only when we want to use chromium from a specific path ( incase we don't have chromium in bench folder )
-		self.CHROMIUM_BINARY_PATH = site_config.get("chromium_binary_path", "")
+		self.CHROMIUM_BINARY_PATH = site_config.get("chromium_binary_path") or site_config.get("chromium_path", "")
 		"""
 		Number of allowed open websocket connections to chromium.
 		This number will basically define how many concurrent requests can be handled by one chromium instance.


### PR DESCRIPTION
Added support for the chromium_path key while maintaining backward compatibility with chromium_binary_path. This ensures Print Designer follows the same configuration standards as Frappe Core.

Closes https://github.com/frappe/print_designer/issues/522