### PR TITLE
Delete the property setter on uninstall

### DIFF
--- a/print_designer/install.py
+++ b/print_designer/install.py
@@ -319,10 +319,10 @@ def calculate_platform():
 
 
 def add_pdf_generator_option():
-	set_pdf_generator_option("add")
+	set_pdf_generator_option()
 
 
-def set_pdf_generator_option(action: Literal["add", "remove"]):
+def set_pdf_generator_option():
 	field = frappe.get_meta("Print Format").get_field("pdf_generator")
 
 	if not field:
@@ -330,15 +330,11 @@ def set_pdf_generator_option(action: Literal["add", "remove"]):
 
 	options = (field.options).split("\n")
 
-	if "chrome" in options and action == "add":
+	if "chrome" in options:
 		return
 
-	if action == "add":
-		if "chrome" not in options:
-			options.append("chrome")
-	elif action == "remove":
-		if "chrome" in options:
-			options.remove("chrome")
+	if "chrome" not in options:
+		options.append("chrome")
 
 	make_property_setter(
 		"Print Format",

--- a/print_designer/uninstall.py
+++ b/print_designer/uninstall.py
@@ -1,7 +1,6 @@
 import frappe
 
 from print_designer.custom_fields import CUSTOM_FIELDS
-from print_designer.install import set_pdf_generator_option
 from frappe.custom.doctype.property_setter.property_setter import delete_property_setter
 
 

--- a/print_designer/uninstall.py
+++ b/print_designer/uninstall.py
@@ -2,6 +2,7 @@ import frappe
 
 from print_designer.custom_fields import CUSTOM_FIELDS
 from print_designer.install import set_pdf_generator_option
+from frappe.custom.doctype.property_setter.property_setter import delete_property_setter
 
 
 def delete_custom_fields(custom_fields):
@@ -31,7 +32,7 @@ def delete_custom_fields(custom_fields):
 
 
 def remove_pdf_generator_option():
-	set_pdf_generator_option("remove")
+	delete_property_setter("Print Format", "pdf_generator")
 
 
 def before_uninstall():

--- a/print_designer/uninstall.py
+++ b/print_designer/uninstall.py
@@ -32,7 +32,7 @@ def delete_custom_fields(custom_fields):
 
 
 def remove_pdf_generator_option():
-	delete_property_setter("Print Format", "pdf_generator")
+	delete_property_setter("Print Format", field_name="pdf_generator")
 
 
 def before_uninstall():

--- a/print_designer/uninstall.py
+++ b/print_designer/uninstall.py
@@ -32,7 +32,7 @@ def delete_custom_fields(custom_fields):
 
 
 def remove_pdf_generator_option():
-	delete_property_setter("Print Format", field_name="pdf_generator")
+	delete_property_setter("Print Format", property="options", field_name="pdf_generator")
 
 
 def before_uninstall():


### PR DESCRIPTION
The property setter that overrides the available print pdf_generator is set to a wrong value on v16.