### PR TITLE
fix: delete property setter on uninstall instead of removing chrome option

### DIFF
--- a/print_designer/install.py
+++ b/print_designer/install.py
@@ -3,7 +3,6 @@ import platform
 import shutil
 import zipfile
 from pathlib import Path
-from typing import Literal
 
 import click
 import frappe
@@ -319,10 +318,10 @@ def calculate_platform():
 
 
 def add_pdf_generator_option():
-	set_pdf_generator_option("add")
+	set_pdf_generator_option()
 
 
-def set_pdf_generator_option(action: Literal["add", "remove"]):
+def set_pdf_generator_option():
 	field = frappe.get_meta("Print Format").get_field("pdf_generator")
 
 	if not field:
@@ -330,15 +329,10 @@ def set_pdf_generator_option(action: Literal["add", "remove"]):
 
 	options = (field.options).split("\n")
 
-	if "chrome" in options and action == "add":
+	if "chrome" in options:
 		return
 
-	if action == "add":
-		if "chrome" not in options:
-			options.append("chrome")
-	elif action == "remove":
-		if "chrome" in options:
-			options.remove("chrome")
+	options.append("chrome")
 
 	make_property_setter(
 		"Print Format",

--- a/print_designer/uninstall.py
+++ b/print_designer/uninstall.py
@@ -1,7 +1,7 @@
 import frappe
 
 from print_designer.custom_fields import CUSTOM_FIELDS
-from print_designer.install import set_pdf_generator_option
+from frappe.custom.doctype.property_setter.property_setter import delete_property_setter
 
 
 def delete_custom_fields(custom_fields):
@@ -31,7 +31,7 @@ def delete_custom_fields(custom_fields):
 
 
 def remove_pdf_generator_option():
-	set_pdf_generator_option("remove")
+	delete_property_setter("Print Format", property="options", field_name="pdf_generator")
 
 
 def before_uninstall():


### PR DESCRIPTION
## Problem

On uninstall, `set_pdf_generator_option("remove")` reads merged options via `get_meta`, removes `chrome`, then writes a Property Setter with the result. On Frappe v16 the `pdf_generator` field natively ships `wkhtmltopdf\nchrome`, so this leaves behind a Property Setter forcing options to `wkhtmltopdf` only chrome stays gone after uninstall.

## Solution

Replace the remove path with `delete_property_setter("Print Format", property="options", field_name="pdf_generator")`. Override is dropped, native field definition takes over. Works on both v15 (native `wkhtmltopdf`) and v16 (native `wkhtmltopdf\nchrome`).