### PR TITLE
fix: header overlay and hidden mouse pointer icon

### DIFF
--- a/print_designer/print_designer/page/print_designer/print_designer.js
+++ b/print_designer/print_designer/page/print_designer/print_designer.js
@@ -1,4 +1,10 @@
 frappe.pages["print-designer"].on_page_load = function (wrapper) {
+	frappe.ui.make_app_page({
+		parent: wrapper,
+		single_column: true,
+		hide_sidebar: true,
+	});
+	wrapper.page.page_head.hide();
 	// hot reload in development
 	if (frappe.boot.developer_mode) {
 		frappe.hot_update = frappe.hot_update || [];

--- a/print_designer/print_designer/page/print_designer/print_designer.js
+++ b/print_designer/print_designer/page/print_designer/print_designer.js
@@ -178,9 +178,6 @@ const load_print_designer = async (wrapper) => {
 		if (is_print_format) {
 			await set_current_doc(route[1]);
 			await frappe.require("print_designer.bundle.js");
-			if (frappe.print_designer?.print_format === route[1] && frappe.print_designer?.app) {
-				return;
-			}
 			frappe.print_designer?.destroy?.();
 			frappe.print_designer = new frappe.ui.PrintDesigner({
 				wrapper: $parent,

--- a/print_designer/print_designer/page/print_designer/print_designer.js
+++ b/print_designer/print_designer/page/print_designer/print_designer.js
@@ -178,6 +178,10 @@ const load_print_designer = async (wrapper) => {
 		if (is_print_format) {
 			await set_current_doc(route[1]);
 			await frappe.require("print_designer.bundle.js");
+			if (frappe.print_designer?.print_format === route[1] && frappe.print_designer?.app) {
+				return;
+			}
+			frappe.print_designer?.destroy?.();
 			frappe.print_designer = new frappe.ui.PrintDesigner({
 				wrapper: $parent,
 				print_format: route[1],

--- a/print_designer/public/js/print_designer/App.vue
+++ b/print_designer/public/js/print_designer/App.vue
@@ -109,7 +109,7 @@ watchEffect(() => {
 .main-layout {
 	display: flex;
 	justify-content: space-between;
-	margin: 0;
+	margin: calc(var(--navbar-height) - 1px) 0 0;
 	cursor: default;
 	--primary: #7b4b57;
 	--primary-color: #7b4b57;

--- a/print_designer/public/js/print_designer/components/layout/AppHeader.vue
+++ b/print_designer/public/js/print_designer/components/layout/AppHeader.vue
@@ -111,11 +111,12 @@ const goToLastPage = () => {
 </script>
 <style scoped lang="scss">
 .header {
-	position: absolute;
+	position: fixed;
 	top: 0;
 	left: 0;
+	right: 0;
 	display: flex;
-	justify-content: space-between;
+	justify-content: flex-start;
 	align-items: center;
 	gap: 16px;
 	height: calc(var(--navbar-height) - 1px);

--- a/print_designer/public/js/print_designer/icons/Icons.vue
+++ b/print_designer/public/js/print_designer/icons/Icons.vue
@@ -42,19 +42,12 @@
 			</defs>
 		</symbol>
 		<symbol id="mouseTool" fill="none" viewBox="0 0 16 16">
-			<g clip-path="url(#a)">
-				<path
-					fill="var(--icon-stroke)"
-					fill-rule="evenodd"
-					d="M.646.646a.5.5 0 0 0-.119.517l4.828 14a.5.5 0 0 0 .927.046L9.1 9.102l1.781-.823 4.328-1.996a.5.5 0 0 0-.047-.927l-14-4.828a.5.5 0 0 0-.517.12Zm7.478 8.185-2.23 4.83L1.808 1.807l11.854 4.088-3.198 1.475-1.632.754-2.167-2.167a.5.5 0 1 0-.707.707L8.124 8.83Z"
-					clip-rule="evenodd"
-				/>
-			</g>
-			<defs>
-				<clipPath id="a">
-					<path fill="#fff" d="M16 0H0v16h16z" />
-				</clipPath>
-			</defs>
+			<path
+				fill="var(--icon-stroke)"
+				fill-rule="evenodd"
+				d="M.646.646a.5.5 0 0 0-.119.517l4.828 14a.5.5 0 0 0 .927.046L9.1 9.102l1.781-.823 4.328-1.996a.5.5 0 0 0-.047-.927l-14-4.828a.5.5 0 0 0-.517.12Zm7.478 8.185-2.23 4.83L1.808 1.807l11.854 4.088-3.198 1.475-1.632.754-2.167-2.167a.5.5 0 1 0-.707.707L8.124 8.83Z"
+				clip-rule="evenodd"
+			/>
 		</symbol>
 		<symbol id="textTool" fill="none" viewBox="0 0 16 16">
 			<path

--- a/print_designer/public/js/print_designer/print_designer.bundle.js
+++ b/print_designer/public/js/print_designer/print_designer.bundle.js
@@ -5,10 +5,11 @@ class PrintDesigner {
 	constructor({ wrapper, print_format }) {
 		this.$wrapper = $(wrapper);
 		this.print_format = print_format;
+		const mountTarget = this.$wrapper.find(".layout-main-section").get(0) || this.$wrapper.get(0);
 		this.app = createApp(Designer, { print_format_name: this.print_format });
 		this.app.use(createPinia());
 		SetVueGlobals(this.app);
-		this.app.mount(this.$wrapper.get(0));
+		this.app.mount(mountTarget);
 		const headerContainer = document.querySelector("header .container");
 		if (headerContainer) {
 			headerContainer.style.width = "100%";

--- a/print_designer/public/js/print_designer/print_designer.bundle.js
+++ b/print_designer/public/js/print_designer/print_designer.bundle.js
@@ -5,20 +5,27 @@ class PrintDesigner {
 	constructor({ wrapper, print_format }) {
 		this.$wrapper = $(wrapper);
 		this.print_format = print_format;
-		const app = createApp(Designer, { print_format_name: this.print_format });
-		app.use(createPinia());
-		SetVueGlobals(app);
-		app.mount(this.$wrapper.get(0));
-		let headerContainer = document.querySelector("header .container");
-		headerContainer.style.width = "100%";
-		headerContainer.style.minWidth = "100%";
-		headerContainer.style.userSelect = "none";
-		frappe.router.once("change", () => {
-			headerContainer.style.width = null;
-			headerContainer.style.minWidth = null;
-			headerContainer.style.userSelect = "auto";
-			app.unmount();
-		});
+		this.app = createApp(Designer, { print_format_name: this.print_format });
+		this.app.use(createPinia());
+		SetVueGlobals(this.app);
+		this.app.mount(this.$wrapper.get(0));
+		const headerContainer = document.querySelector("header .container");
+		if (headerContainer) {
+			headerContainer.style.width = "100%";
+			headerContainer.style.minWidth = "100%";
+			headerContainer.style.userSelect = "none";
+			this.resetHeader = () => {
+				headerContainer.style.width = null;
+				headerContainer.style.minWidth = null;
+				headerContainer.style.userSelect = "auto";
+			};
+		}
+		frappe.router.once("change", () => this.destroy());
+	}
+	destroy() {
+		this.resetHeader?.();
+		this.app?.unmount?.();
+		this.app = null;
 	}
 }
 


### PR DESCRIPTION
Fixes #521.

* Switched header from `absolute` to `fixed` with `right: 0` so Desk navbar no longer overlaps it, and offset `.main-layout` to prevent toolbar clipping.
* Removed conflicting SVG `clipPath id="a"` wrapper that caused the mouse pointer icon to disappear due to global SVG ID collisions.
* Added null guard for `header .container` since desk no longer renders it.
* Exposed `destroy()` on the page controller to centralize Vue app teardown.

<img width="1512" height="867" alt="Screenshot 2026-05-18 at 11 55 40 PM" src="https://github.com/user-attachments/assets/b77dbaf7-665a-4191-a50b-682502daf1fb" />
