### PR TITLE
fix: release chromium browser when pdf generation raises

### DIFF
--- a/print_designer/pdf_generator/browser.py
+++ b/print_designer/pdf_generator/browser.py
@@ -19,45 +19,46 @@ class Browser:
 		self.is_print_designer = frappe.get_cached_value("Print Format", print_format, "print_designer")
 		self.browserID = frappe.utils.random_string(10)
 		generator.add_browser(self.browserID)
-		# sets soup from html
-		self.set_html(html)
-		# sets wkhtmltopdf options
-		self.set_options(options)
-		# start cdp connection and create browser context ( kind of like new window / incognito mode)
-		self.open(generator)
-		# opens header and footer pages and sets content ( not waiting for it to load)
-		self.prepare_header_footer()
-		# opens body page and sets content and waits for it to finshing load
-		self.setup_body_page()
-		# prepare options as per chrome for pdf
-		self.prepare_options_for_pdf()
-		# generate header and footer pages if they are not dynamic ( first, odd, even, last)
-		self.update_header_footer_page_pd()
-		# if header and footer are not dynamic start generating pdf for them (non-blocking)
-		self.try_async_header_footer_pdf()
-		# now wait for page to load as we need DOM to generate pdf
-		self.body_page.wait_for_set_content()
-		self.body_pdf = self.body_page.generate_pdf(raw=not self.header_page and not self.footer_page)
-		self.body_page.close()
-		self.update_header_footer_page()
+		try:
+			# sets soup from html
+			self.set_html(html)
+			# sets wkhtmltopdf options
+			self.set_options(options)
+			# start cdp connection and create browser context ( kind of like new window / incognito mode)
+			self.open(generator)
+			# opens header and footer pages and sets content ( not waiting for it to load)
+			self.prepare_header_footer()
+			# opens body page and sets content and waits for it to finshing load
+			self.setup_body_page()
+			# prepare options as per chrome for pdf
+			self.prepare_options_for_pdf()
+			# generate header and footer pages if they are not dynamic ( first, odd, even, last)
+			self.update_header_footer_page_pd()
+			# if header and footer are not dynamic start generating pdf for them (non-blocking)
+			self.try_async_header_footer_pdf()
+			# now wait for page to load as we need DOM to generate pdf
+			self.body_page.wait_for_set_content()
+			self.body_pdf = self.body_page.generate_pdf(raw=not self.header_page and not self.footer_page)
+			self.body_page.close()
+			self.update_header_footer_page()
 
-		if self.header_page:
-			if not self.is_header_dynamic:
-				self.header_pdf = self.header_page.get_pdf_from_stream(self.header_page.get_pdf_stream_id())
-			else:
-				self.header_pdf = self.header_page.generate_pdf()
-			self.header_page.close()
+			if self.header_page:
+				if not self.is_header_dynamic:
+					self.header_pdf = self.header_page.get_pdf_from_stream(self.header_page.get_pdf_stream_id())
+				else:
+					self.header_pdf = self.header_page.generate_pdf()
+				self.header_page.close()
 
-		if self.footer_page:
-			if not self.is_footer_dynamic:
-				self.footer_pdf = self.footer_page.get_pdf_from_stream(self.footer_page.get_pdf_stream_id())
-			else:
-				self.footer_pdf = self.footer_page.generate_pdf()
-			self.footer_page.close()
+			if self.footer_page:
+				if not self.is_footer_dynamic:
+					self.footer_pdf = self.footer_page.get_pdf_from_stream(self.footer_page.get_pdf_stream_id())
+				else:
+					self.footer_pdf = self.footer_page.generate_pdf()
+				self.footer_page.close()
 
-		self.close()
-
-		generator.remove_browser(self.browserID)
+			self.close()
+		finally:
+			generator.remove_browser(self.browserID)
 
 	def open(self, generator):
 		# checking because if we share browser accross request _devtools_url will already be set for subsequent requests.

--- a/print_designer/pdf_generator/generator.py
+++ b/print_designer/pdf_generator/generator.py
@@ -27,7 +27,8 @@ class FrappePDFGenerator:
 		self._browsers.append(browser)
 
 	def remove_browser(self, browser):
-		self._browsers.remove(browser)
+		if browser in self._browsers:
+			self._browsers.remove(browser)
 
 	def __new__(cls):
 		# if instance or _chromium_process is not available create object else return current instance stored in cls._instance

--- a/print_designer/pdf_generator/pdf.py
+++ b/print_designer/pdf_generator/pdf.py
@@ -40,7 +40,12 @@ def get_pdf(print_format, html, options, output, pdf_generator=None):
 	# scrubbing url to expand url is not required as we have set url.
 	# also, planning to remove network requests anyway 🤞
 	generator = FrappePDFGenerator()
-	browser = Browser(generator, print_format, html, options)
-	transformer = PDFTransformer(browser)
-	# transforms and merges header, footer into body pdf and returns merged pdf
-	return transformer.transform_pdf(output=output)
+	browser = None
+	try:
+		browser = Browser(generator, print_format, html, options)
+		transformer = PDFTransformer(browser)
+		# transforms and merges header, footer into body pdf and returns merged pdf
+		return transformer.transform_pdf(output=output)
+	finally:
+		if browser is not None:
+			generator.remove_browser(browser.browserID)


### PR DESCRIPTION
## Summary

Fixes a Chromium cleanup issue where failed renders could leave orphaned browser instances running in the background.

`add_browser` is called at the beginning of `Browser.__init__`, but `remove_browser` only ran if the entire initialization completed successfully. If an exception happened anywhere in the flow (`set_html`, `open`, `prepare_header_footer`, page generation, etc.), the browser ID stayed in `_browsers`.

Because of that, `_close_browser` would think there were still active browser instances and skip shutting down Chromium entirely.

Over time this caused:

* orphaned Chromium subprocesses
* increasing RAM usage
* stale CDP connections being kept alive

## Changes

* Wrapped the main work inside `Browser.__init__` with `try/finally` so `remove_browser` always runs
* Wrapped the caller inside `pdf.get_pdf` with `try/finally` for additional cleanup safety
* Made `remove_browser` idempotent so duplicate cleanup calls are safe
