### PR TITLE
fix: rebuild chromium singleton when subprocess has exited

### DIFF
--- a/print_designer/pdf_generator/generator.py
+++ b/print_designer/pdf_generator/generator.py
@@ -30,8 +30,14 @@ class FrappePDFGenerator:
 		self._browsers.remove(browser)
 
 	def __new__(cls):
-		# if instance or _chromium_process is not available create object else return current instance stored in cls._instance
-		if cls._instance is None or not cls._instance._chromium_process:
+		# Rebuild singleton when chromium subprocess is missing or has exited.
+		# subprocess.Popen stays truthy after the underlying process dies, so
+		# `not cls._instance._chromium_process` never trips — use poll() instead.
+		if (
+			cls._instance is None
+			or cls._instance._chromium_process is None
+			or cls._instance._chromium_process.poll() is not None
+		):
 			cls._instance = super().__new__(cls)
 		return cls._instance
 


### PR DESCRIPTION
## Bug

PDF generation intermittently fails with `ConnectionRefusedError` on a stale localhost ephemeral port after the Chromium subprocess dies while the worker still holds the singleton instance.

## Cause

`ChromePDFGenerator.__new__` only checks:

```python
not cls._instance._chromium_process
```

But `_chromium_process` is a `subprocess.Popen` object, which stays truthy even after the process exits. This causes reuse of a stale singleton with an outdated `_devtools_url`, leading to failed CDP connections.

## Fix

Use `Popen.poll()` to detect exited Chromium processes and recreate the singleton when needed. The new instance refreshes `_devtools_url` automatically.

## Repro

1. Trigger a PDF request.
2. Kill Chromium:

```bash
pkill -9 -f chromium
```

3. Trigger another PDF request on the same worker.

Before: `ConnectionRefusedError` on the old port.
After: Chromium respawns and the request succeeds.
