### PR TITLE
fix: typo "Milimeter" -> "Millimeter" in Page UOM dropdown

### DIFF
--- a/print_designer/public/js/print_designer/PropertiesPanelState.js
+++ b/print_designer/public/js/print_designer/PropertiesPanelState.js
@@ -380,7 +380,7 @@ export const createPropertiesPanel = () => {
 						requiredData: () => page.value.UOM,
 						options: () => [
 							{ label: "Pixels (px)", value: "px" },
-							{ label: "Milimeter (mm)", value: "mm" },
+							{ label: "Millimeter (mm)", value: "mm" },
 							{ label: "Centimeter (cm)", value: "cm" },
 							{ label: "Inch (in)", value: "in" },
 						],


### PR DESCRIPTION
The Page UOM dropdown in the editor Properties panel labels the millimeter option as "Milimeter (mm)" (missing an l). Small user-visible typo. File: print_designer/public/js/print_designer/PropertiesPanelState.js