### PR TITLE
fix(install): mention Version 16 in version-check error message

### DIFF
--- a/print_designer/install.py
+++ b/print_designer/install.py
@@ -26,7 +26,7 @@ def check_frappe_version():
 
 	click.secho(
 		f"You're attempting to install Print Designer with Frappe version {frappe_version}. "
-		"This is not supported and will result in broken install. Please install it using Version 15 or Develop branch.",
+		"This is not supported and will result in broken install. Please install it using Version 15, Version 16, or Develop branch.",
 		fg="red",
 	)
 	raise SystemExit(1)


### PR DESCRIPTION
`check_frappe_version()` already accepts `>= 15` and passes on Frappe v16, but the error message shown when installing on an unsupported (older) version still reads "Version 15 or Develop branch". Since v16 works, mentioning it reduces user uncertainty about whether v16 is supported.

File: print_designer/install.py