### PR TITLE
feat(page): accept ?format=<name> query deep-link for the editor

### DIFF
--- a/print_designer/print_designer/page/print_designer/print_designer.js
+++ b/print_designer/print_designer/page/print_designer/print_designer.js
@@ -167,6 +167,17 @@ const set_current_doc = async (format_name) => {
 
 const load_print_designer = async (wrapper) => {
 	let route = frappe.get_route();
+	// Support `?format=<name>` (or `?print_format=<name>`) query deep-links.
+	// `/app/print-designer/<name>` already works via the path; this lets callers
+	// (e.g. "Open in Print Designer" links / PDF preview) use the query form too.
+	if (route.length <= 1 && frappe.utils.get_query_params) {
+		const qp = frappe.utils.get_query_params() || {};
+		const fmt = qp.format || qp.print_format;
+		if (fmt) {
+			frappe.set_route("print-designer", fmt);
+			return;
+		}
+	}
 	let $parent = $(wrapper);
 	let is_print_format;
 	let message = `Print Format <b>${route[1]}</b> not found. <hr/> Would you like to Create or Edit other Print Format?`;


### PR DESCRIPTION
Currently `/app/print-designer/<name>` opens a format in the editor via the route path, but `/app/print-designer?format=<name>` (the query form other Frappe pages accept for cross-linking) only shows the landing modal.

This adds a small redirect at the start of `load_print_designer` so callers (e.g. "Open in Print Designer" links from forms, PDF preview) can use either form. Falls back to existing behavior when no query param is present.

File: print_designer/print_designer/page/print_designer/print_designer.js