### PR TITLE
fix: fall back to standard preview when a format has no designer settings

### DIFF
--- a/print_designer/print_designer/client_scripts/print.js
+++ b/print_designer/print_designer/client_scripts/print.js
@@ -183,7 +183,11 @@ frappe.ui.form.PrintView = class PrintView extends frappe.ui.form.PrintView {
 	}
 	preview() {
 		let print_format = this.get_print_format();
-		if (print_format.print_designer && print_format.print_designer_body) {
+		if (
+			print_format.print_designer &&
+			print_format.print_designer_body &&
+			print_format.print_designer_settings
+		) {
 			this.inner_msg.hide();
 			this.print_wrapper.find(".print-preview-wrapper").hide();
 			this.print_wrapper.find(".preview-beta-wrapper").hide();


### PR DESCRIPTION
- Selecting a print format that has `print_designer_body` but no `print_designer_settings` crashed the print view (`Cannot read properties of null (reading 'page')` in `designer_pdf`) and left the previous format's preview on screen
- `preview()` now also requires `print_designer_settings` before taking the designer path, so half-created formats fall back to the standard preview instead of throwing

Why: a Print Format created with the designer flag but never opened/saved in the designer stores an empty body shell and null settings — `JSON.parse(null).page` throws before any fallback can run.
