### PR TITLE
fix(pdf): re-frame body pages on footer-only print formats

### DIFF
--- a/print_designer/pdf_generator/pdf_merge.py
+++ b/print_designer/pdf_generator/pdf_merge.py
@@ -49,15 +49,18 @@ class PDFTransformer:
 		if header:
 			header_height = header.pages[0].mediabox.top
 			header_transform = body_height + footer_height
-			header_body_top = header_height + body_height + footer_height
+
+		# header_height is 0 when there is no header, so this is the same value as
+		# before for header and header+footer formats. For a footer-only format it
+		# is now non-zero instead of 0, which is what lets the body be re-framed.
+		header_body_top = header_height + body_height + footer_height
 
 		if header and not self.is_header_dynamic:
 			for h in header.pages:
 				self._transform(h, header_body_top, header_transform)
 
 		for p in body.pages:
-			if header_body_top:
-				self._transform(p, header_body_top, body_transform)
+			self._transform(p, header_body_top, body_transform)
 			if header:
 				if self.is_header_dynamic:
 					p.merge_page(self._transform(header.pages[p.page_number], header_body_top, header_transform))


### PR DESCRIPTION
### Problem

`PDFTransformer.transform_pdf()` computes `header_body_top` only inside `if header:`, and only re-frames the body pages when that value is truthy:

```python
if header:
    header_height = header.pages[0].mediabox.top
    header_transform = body_height + footer_height
    header_body_top = header_height + body_height + footer_height   # only set here

for p in body.pages:
    if header_body_top:                                            # 0 when footer-only
        self._transform(p, header_body_top, body_transform)
```

On a print format with a **repeating footer and no repeating header**, `header_body_top` stays `0`, so the body page is never restored to full page height and never translated up by the footer's height.

Chrome has already rendered the body at `paperHeight = page_height - (footer_height + margin_bottom)` with `marginBottom = 0`. The footer PDF is then merged over the bottom of the body content on every page — roughly the bottom 35 mm on A4 for a typical footer. Anything that lands there is silently covered.

We hit this on a Sales Invoice format whose footer carries a payment QR code: the QR was cut off on every generated invoice.

### Fix

Compute `header_body_top` unconditionally and drop the guard.

`header_height` is initialised to `0` and only assigned when a header exists, so:

| format | before | after |
|---|---|---|
| header only | `header_height + body_height + 0` | unchanged |
| header + footer | `header_height + body_height + footer_height` | unchanged |
| **footer only** | `0` — body not re-framed | `0 + body_height + footer_height` |

Only the footer-only case changes behaviour. The `if header_body_top:` guard becomes redundant once the value is always computed, and `transform_pdf()` early-returns when there is neither a header nor a footer, so the loop is only reached when at least one exists.

### Verification

This exact change has been running in production since 2026-08-01 on a self-hosted ERPNext v15 instance, applied as a local patch over `print_designer` 1.6.5.

- Footer-only formats now render the full body; the previously-clipped footer QR is intact.
- Header-only and header+footer formats produce byte-identical PDFs to before the change, rendered through the same `chromium-headless-shell` build.

Still present on `develop` as of 2026-08-02.
