### PR TITLE
fix: repair chromium exec bit when the binary is already downloaded

### DIFF
--- a/print_designer/install.py
+++ b/print_designer/install.py
@@ -97,6 +97,7 @@ def find_or_download_chromium_executable():
 		download_chromium()
 	else:
 		click.echo(f"Chromium is already set up at {exec_path}")
+		make_chromium_executable(exec_path)
 
 	if not exec_path.exists():
 		click.echo("Error while downloading chrome")

--- a/print_designer/pdf_generator/generator.py
+++ b/print_designer/pdf_generator/generator.py
@@ -111,7 +111,7 @@ class FrappePDFGenerator:
 		exec_path = Path(chromium_dir).joinpath(*executable_name)
 		if not exec_path.exists():
 			frappe.throw(
-				f"Chromium executable not found: {exec_path}. please run bench setup-new-pdf-backend"
+				f"Chromium executable not found: {exec_path}. please run bench setup-chrome"
 			)
 
 		return str(exec_path)


### PR DESCRIPTION
## Description

If the Chromium binary exists but is not executable, PDF generation fails with `Chromium not executable`.

The recovery logic only checks whether the file exists, so it skips `download_chromium()` and never restores the executable bit. This can also break every request because the PDF generator is created in a `before_request` hook.

This fix calls `make_chromium_executable()` when the binary already exists. It is safe to call because the helper does nothing if the executable bit is already set.

The second commit fixes the error message to use the correct command: `bench setup-chrome` instead of the non-existent `bench setup-new-pdf-backend`.

Tested on a v15 bench by removing the executable bit, running `setup_chromium`, and confirming it is restored to `755` after the fix.
