### PR TITLE
fix: pdf header footer

### DIFF
--- a/print_designer/pdf.py
+++ b/print_designer/pdf.py
@@ -15,6 +15,24 @@ def pdf_header_footer_html(soup, head, content, styles, html_id, css):
 	if soup.find(id="__print_designer"):
 		if frappe.form_dict.get("pdf_generator", "wkhtmltopdf") == "chrome":
 			path = "print_designer/page/print_designer/jinja/header_footer.html"
+			# frappe's Browser calls clone_and_update() on the header/footer
+			# page after loading this HTML, but it does NOT inject
+			# update_page_no.js (only print_designer's own Browser does).
+			# Without the script the odd/even/last page variants stay
+			# display:none, Chrome renders a 1-page PDF and frappe's
+			# pdf_merge crashes with IndexError (pages[3]).
+			head = list(head)
+			if not any("clone_and_update" in str(tag) for tag in head):
+				script_path = frappe.get_app_path(
+					"print_designer",
+					"print_designer",
+					"page",
+					"print_designer",
+					"update_page_no.js",
+				)
+				script_tag = soup.new_tag("script")
+				script_tag.append(soup.new_string(frappe.read_file(script_path)))
+				head.append(script_tag)
 		else:
 			path = "print_designer/page/print_designer/jinja/header_footer_old.html"
 		try:


### PR DESCRIPTION
## Bug

Printing a document with a Print Designer format via the chrome PDF generator (Download PDF) fails with:

```pytb
  File "apps/frappe/frappe/utils/pdf_generator/pdf_merge.py", line 64, in transform_pdf
    p.merge_page(header.pages[3])
                 ~~~~~~~~~~~~~~~^
IndexError: Sequence index out of range
```

This happens for **every** Print Designer format when frappe drives the chrome rendering (the `frappe.utils.pdf_generator.browser.Browser` path, which is what `download_pdf` uses) and the header/footer is **not** dynamic (does not use page numbers).

## Root cause

Frappe's chrome PDF pipeline expects a **4-page** header/footer PDF (first, odd, even, last) from Print Designer:

- `frappe/utils/pdf_generator/browser.py` → `update_header_footer_page_pd()` calls `evaluate("clone_and_update('#header-render-container', 0, 1, 'Header', 0);")` on the header page to clone the 4 page variants into the DOM
- `pdf_merge.py` then unconditionally indexes `header.pages[0..3]`

`clone_and_update()` is defined in Print Designer's `update_page_no.js`. Print Designer's own `Browser` injects that script into the `<head>` before rendering the header/footer HTML (`prepare_header_footer()`).

However frappe's `Browser` implementation — copied from Print Designer — calls `clone_and_update()` but **never injects `update_page_no.js`**. Its comments even say "function is added to html from update_page_no.js", but the injection step doesn't exist in frappe.

Result:

1. `Runtime.evaluate("clone_and_update(...)")` fails with a `ReferenceError` — but the error is returned in the CDP response's `exceptionDetails`, which the page's `evaluate()` wrapper does not check. The failure is **silent**.
2. The odd/even/last page variants remain `display: none` in the rendered HTML
3. Chrome prints a **1-page** header/footer PDF
4. `pdf_merge.py` accesses `header.pages[3]` → `IndexError`

## Fix

Since the script lives in this app, inject `update_page_no.js` into the `<head>` of the chrome header/footer HTML from our own `pdf_header_footer_html` hook:

- Append the script tag to the `head` passed to the chrome template
- Guard with `if not any("clone_and_update" in str(tag) ...)` so it's not double-injected when Print Designer's own `Browser` (which already injects it into the soup) renders the same hook

After the fix, `clone_and_update()` runs, the 3 variants are cloned with `display: block`, Chrome generates the expected 4-page header/footer PDF, and `pdf_merge.py` finds `pages[3]`.

## Steps to reproduce

1. Create a Print Designer print format with a static header (no page numbers) — any format works
2. Print any document with it using the chrome PDF generator (Download PDF)
3. Observe the `IndexError: Sequence index out of range` traceback

## Testing

Verified on a v16 bench: PDFs that previously crashed with `IndexError` now render correctly, with the header/footer applied on all pages (first, odd, even, last variants).